### PR TITLE
feat(queue): キュー並び替えと合計時間表示を追加

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -7,3 +7,42 @@ applyTo: 'tests/**'
 - テストランナーコマンド: `pnpm test:unit`（ユニット）、`pnpm test:e2e`（E2E）、`pnpm test`（両方）
 - ユニットテストは `@nuxt/test-utils` の Nuxt 環境で実行される
 - E2E テストは dev サーバーを自動起動して実行される
+
+## ユニットテスト記述のコツ
+
+### import パスは相対パスを使う
+
+`tests/unit/` は Nuxt の tsconfig の `include` 対象外のため、`~/types` や `~/stores/...` の Nuxt エイリアスは IDE の型解決に失敗する。
+**相対パスで import する。**
+
+```ts
+// NG
+import type { Song } from '~/types'
+// OK
+import type { Song } from '../../app/types'
+import { useQueueStore } from '../../app/stores/queue'
+```
+
+### Pinia store を直接テストする場合
+
+`beforeEach` で `setActivePinia(createPinia())` を呼んでストアを初期化する。
+
+```ts
+import { setActivePinia, createPinia } from 'pinia'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+```
+
+### store の配列要素に型が付かない場合
+
+store の state として公開された配列が実行時に `any[]` 型になり、`(s) => s.id` の `s` が暗黙 `any` エラーになることがある。
+**明示的に型を付けたヘルパー関数を用意する。**
+
+```ts
+// tests/unit/queueStore.test.ts の例
+const ids = (arr: Song[]) => arr.map((s) => s.id)
+// ...
+expect(ids(queue.songs)).toEqual([2, 3, 1, 4])
+```

--- a/.github/instructions/vue.instructions.md
+++ b/.github/instructions/vue.instructions.md
@@ -13,3 +13,7 @@ applyTo: '**/*.vue'
 - レスポンシブはモバイルファーストで `lg:` ブレークポイントを基準にする（サイドバー表示切替など）
 - ブラウザ専用 API や YouTube IFrame など SSR 非対応の要素は `<ClientOnly>` で囲む
 - 角丸（`rounded-*`）は使わない。セマンティックカラートークン（`surface-base`, `accent` 等）を優先する
+- ダークモード専用のため、`bg-surface-base`（gray-950）や `bg-surface-raised`（gray-900）上に配置するテキストには**必ず明示的な色クラスを付ける**。色未指定のままにすると暗い背景で読めなくなる
+  - 通常テキスト: `text-gray-50`
+  - 補助テキスト: `text-gray-400`
+  - アクセント: `text-emerald-400`

--- a/app/components/QueueDrawer.vue
+++ b/app/components/QueueDrawer.vue
@@ -7,7 +7,12 @@
       >
         <!-- Header -->
         <div class="flex items-center justify-between border-b border-border-default px-4 py-3">
-          <h2 class="text-sm font-bold">再生キュー</h2>
+          <div class="flex items-center gap-2">
+            <h2 class="text-sm font-bold text-gray-50">再生キュー</h2>
+            <span v-if="queue.songs.length > 0" class="text-xs text-gray-400">
+              {{ queue.songs.length }}曲 &middot; {{ queue.totalDuration }}
+            </span>
+          </div>
           <div class="flex items-center gap-2">
             <button class="text-xs text-gray-400 hover:text-white" @click="queue.clear()">
               クリア
@@ -30,52 +35,80 @@
           <div v-if="queue.songs.length === 0" class="px-4 py-8 text-center text-sm text-gray-500">
             キューに曲がありません
           </div>
-          <div v-else>
-            <button
-              v-for="(song, index) in queue.songs"
-              :key="`${song.id}-${index}`"
-              class="flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-surface-overlay"
-              :class="index === queue.currentIndex ? 'bg-surface-overlay' : ''"
-              @click="jumpTo(index)"
+          <ClientOnly v-else>
+            <VueDraggableNext
+              v-model="draggableQueue"
+              handle=".drag-handle"
+              animation="150"
+              @end="handleDragEnd"
             >
-              <span
-                class="w-5 text-center text-xs"
-                :class="index === queue.currentIndex ? 'text-emerald-400' : 'text-gray-500'"
+              <div
+                v-for="(song, index) in draggableQueue"
+                :key="`${song.id}-${index}`"
+                class="flex w-full items-center gap-2 px-2 py-2 transition-colors hover:bg-surface-overlay"
+                :class="index === queue.currentIndex ? 'bg-surface-overlay' : ''"
               >
-                <svg
-                  v-if="index === queue.currentIndex && player.isPlaying"
-                  class="mx-auto h-3 w-3"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
+                <!-- Drag handle -->
+                <div
+                  class="drag-handle flex shrink-0 cursor-grab items-center justify-center active:cursor-grabbing text-gray-600 hover:text-gray-400"
+                  title="ドラッグで並び替え"
                 >
-                  <path d="M3 22V2l7 4v12l-7 4zm8 0V6l7 4v8l-7 4zm8 0V10l5 3v6l-5 3z" />
-                </svg>
-                <template v-else>{{ index + 1 }}</template>
-              </span>
-              <div class="min-w-0 flex-1">
-                <p
-                  class="truncate text-sm"
-                  :class="index === queue.currentIndex ? 'text-emerald-400 font-medium' : ''"
+                  <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M4 8h16M4 16h16"
+                    />
+                  </svg>
+                </div>
+
+                <!-- Index / playing icon -->
+                <span
+                  class="w-5 shrink-0 text-center text-xs"
+                  :class="index === queue.currentIndex ? 'text-emerald-400' : 'text-gray-500'"
                 >
-                  {{ song.title }}
-                </p>
-                <p class="truncate text-xs text-gray-500">{{ song.artist }}</p>
+                  <svg
+                    v-if="index === queue.currentIndex && player.isPlaying"
+                    class="mx-auto h-3 w-3"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M3 22V2l7 4v12l-7 4zm8 0V6l7 4v8l-7 4zm8 0V10l5 3v6l-5 3z" />
+                  </svg>
+                  <template v-else>{{ index + 1 }}</template>
+                </span>
+
+                <!-- Song info -->
+                <button class="min-w-0 flex-1 text-left" @click="jumpTo(index)">
+                  <p
+                    class="truncate text-sm"
+                    :class="
+                      index === queue.currentIndex ? 'font-medium text-emerald-400' : 'text-gray-50'
+                    "
+                  >
+                    {{ song.title }}
+                  </p>
+                  <p class="truncate text-xs text-gray-500">{{ song.artist }}</p>
+                </button>
+
+                <!-- Remove -->
+                <button
+                  class="shrink-0 text-gray-600 hover:text-white"
+                  @click="queue.removeSong(index)"
+                >
+                  <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
               </div>
-              <button
-                class="shrink-0 text-gray-600 hover:text-white"
-                @click.stop="queue.removeSong(index)"
-              >
-                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </button>
-          </div>
+            </VueDraggableNext>
+          </ClientOnly>
         </div>
       </div>
     </Transition>
@@ -88,8 +121,25 @@
 </template>
 
 <script setup lang="ts">
+import { VueDraggableNext } from 'vue-draggable-next'
+import type { Song } from '~/types'
+
 const queue = useQueueStore()
 const player = usePlayerStore()
+
+const draggableQueue = ref<Song[]>([])
+
+watch(
+  () => queue.songs,
+  (newSongs) => {
+    draggableQueue.value = [...newSongs]
+  },
+  { immediate: true, deep: true },
+)
+
+function handleDragEnd(event: { oldIndex: number; newIndex: number }) {
+  queue.moveSong(event.oldIndex, event.newIndex)
+}
 
 function jumpTo(index: number) {
   queue.currentIndex = index

--- a/app/stores/queue.ts
+++ b/app/stores/queue.ts
@@ -96,6 +96,28 @@ export const useQueueStore = defineStore('queue', () => {
     repeatMode.value = modes[(idx + 1) % modes.length]
   }
 
+  function moveSong(from: number, to: number) {
+    if (from === to) return
+    songs.value.splice(to, 0, songs.value.splice(from, 1)[0])
+    if (currentIndex.value === from) {
+      currentIndex.value = to
+    } else if (from < to && currentIndex.value > from && currentIndex.value <= to) {
+      currentIndex.value--
+    } else if (from > to && currentIndex.value >= to && currentIndex.value < from) {
+      currentIndex.value++
+    }
+  }
+
+  const totalDuration = computed(() => {
+    const totalSeconds = songs.value.reduce((sum, song) => {
+      return sum + Math.max(0, song.end_at - song.start_at)
+    }, 0)
+    const hours = Math.floor(totalSeconds / 3600)
+    const minutes = Math.floor((totalSeconds % 3600) / 60)
+    if (hours > 0) return `${hours}時間${minutes}分`
+    return `${minutes}分`
+  })
+
   function toggleOpen() {
     isOpen.value = !isOpen.value
   }
@@ -109,10 +131,12 @@ export const useQueueStore = defineStore('queue', () => {
     currentSong,
     hasNext,
     hasPrevious,
+    totalDuration,
     setSongs,
     addSong,
     addSongNext,
     removeSong,
+    moveSong,
     clear,
     next,
     previous,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "nuxt": "^4.4.2",
     "pinia": "^3.0.4",
     "vue": "^3.5.30",
+    "vue-draggable-next": "^2.3.0",
     "vue-router": "^5.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       vue:
         specifier: ^3.5.30
         version: 3.5.30(typescript@5.9.3)
+      vue-draggable-next:
+        specifier: ^2.3.0
+        version: 2.3.0(sortablejs@1.15.7)(vue@3.5.30(typescript@5.9.3))
       vue-router:
         specifier: ^5.0.3
         version: 5.0.4(@vue/compiler-sfc@3.5.30)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
@@ -3974,6 +3977,9 @@ packages:
     resolution: {integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==}
     engines: {node: '>=20.0.0'}
 
+  sortablejs@1.15.7:
+    resolution: {integrity: sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4521,6 +4527,12 @@ packages:
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
+
+  vue-draggable-next@2.3.0:
+    resolution: {integrity: sha512-ymbY0UIwfSdg0iDN/iyNNwUrTqZ/6KbPryzsvTNXBLuDCuOBdNijSK8yynNtmiSj6RapTPQfjLGQdJrZkzBd2w==}
+    peerDependencies:
+      sortablejs: ^1.14.0
+      vue: ^3.5.17
 
   vue-eslint-parser@10.4.0:
     resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
@@ -8829,6 +8841,8 @@ snapshots:
 
   smob@1.6.1: {}
 
+  sortablejs@1.15.7: {}
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -9364,6 +9378,11 @@ snapshots:
   vue-component-type-helpers@2.2.12: {}
 
   vue-devtools-stub@0.1.0: {}
+
+  vue-draggable-next@2.3.0(sortablejs@1.15.7)(vue@3.5.30(typescript@5.9.3)):
+    dependencies:
+      sortablejs: 1.15.7
+      vue: 3.5.30(typescript@5.9.3)
 
   vue-eslint-parser@10.4.0(eslint@10.0.3(jiti@2.6.1)):
     dependencies:

--- a/tests/unit/queueStore.test.ts
+++ b/tests/unit/queueStore.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { Song } from '../../app/types'
+import { useQueueStore } from '../../app/stores/queue'
+
+const makeSong = (id: number, durationSec = 180): Song => ({
+  id,
+  title: `Song ${id}`,
+  artist: `Artist ${id}`,
+  is_original: false,
+  start_at: 0,
+  end_at: durationSec,
+  video: {
+    id: `video_${id}`,
+    title: `Video ${id}`,
+    url: `https://youtube.com/watch?v=video_${id}`,
+    thumbnail_path: '',
+    is_open: true,
+    is_member_only: false,
+    is_stream: false,
+    unplayable: false,
+    published_at: '2024-01-01T00:00:00Z',
+  },
+})
+
+const ids = (arr: Song[]) => arr.map((s) => s.id)
+
+describe('useQueueStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  // --- moveSong ---
+
+  describe('moveSong', () => {
+    it('後ろへ移動: インデックスが正しく入れ替わる', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3), makeSong(4)], 0)
+      queue.moveSong(0, 2)
+      expect(ids(queue.songs)).toEqual([2, 3, 1, 4])
+    })
+
+    it('前へ移動: インデックスが正しく入れ替わる', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3), makeSong(4)], 0)
+      queue.moveSong(3, 1)
+      expect(ids(queue.songs)).toEqual([1, 4, 2, 3])
+    })
+
+    it('同じ位置への移動は何もしない', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3)], 1)
+      queue.moveSong(1, 1)
+      expect(ids(queue.songs)).toEqual([1, 2, 3])
+      expect(queue.currentIndex).toBe(1)
+    })
+
+    it('現在曲を移動しても currentIndex が追従する', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3)], 0)
+      // 曲1(index=0)を index=2 へ移動
+      queue.moveSong(0, 2)
+      expect(queue.currentIndex).toBe(2)
+      expect(queue.currentSong?.id).toBe(1)
+    })
+
+    it('現在曲より前の曲を後ろへ移動すると currentIndex が 1 減る', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3)], 2)
+      // 曲1(index=0)を index=2 へ移動 → currentIndex が 2→1
+      queue.moveSong(0, 2)
+      expect(queue.currentIndex).toBe(1)
+      expect(queue.currentSong?.id).toBe(3)
+    })
+
+    it('現在曲より後ろの曲を前へ移動すると currentIndex が 1 増える', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3)], 0)
+      // 曲3(index=2)を index=0 へ移動 → currentIndex が 0→1
+      queue.moveSong(2, 0)
+      expect(queue.currentIndex).toBe(1)
+      expect(queue.currentSong?.id).toBe(1)
+    })
+
+    it('影響範囲外の移動では currentIndex が変わらない', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3), makeSong(4)], 0)
+      // index=1 を index=3 へ移動 → currentIndex=0 は影響なし
+      queue.moveSong(1, 3)
+      expect(queue.currentIndex).toBe(0)
+      expect(queue.currentSong?.id).toBe(1)
+    })
+  })
+
+  // --- totalDuration ---
+
+  describe('totalDuration', () => {
+    it('空キューは "0分" を返す', () => {
+      const queue = useQueueStore()
+      expect(queue.totalDuration).toBe('0分')
+    })
+
+    it('合計秒数が分単位で表示される', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1, 180), makeSong(2, 120)], 0)
+      // 300秒 = 5分
+      expect(queue.totalDuration).toBe('5分')
+    })
+
+    it('1時間以上は時間と分で表示される', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1, 3660)], 0)
+      // 3660秒 = 1時間1分
+      expect(queue.totalDuration).toBe('1時間1分')
+    })
+  })
+})


### PR DESCRIPTION
Closes #9

## 概要

QueueDrawer をドラッグで並び替えできる「編集画面」に強化し、合計時間表示も追加しました。

## 変更内容

### `app/stores/queue.ts`
- `moveSong(from, to)` を追加
  - `songs` 配列の並び替えと共に `currentIndex` を正しく補正
  - 補正ロジックは store に集約し、UI 側には持たせない設計
- `totalDuration` computed を追加
  - `end_at - start_at` の合計を「X分」または「X時間Y分」形式で返す

### `app/components/QueueDrawer.vue`
- ヘッダーに曲数と合計時間を表示（例: `3曲 · 12分`）
- `vue-draggable-next` + `<ClientOnly>` でドラッグ並び替えを実装（SSR ハイドレーション不一致を回避）
- 各行の左端に `≡` ドラッグハンドルを追加（`.drag-handle`）
- `handleDragEnd` で `event.oldIndex / newIndex` を `queue.moveSong()` に委譲
- `watch` で store の `songs` 変化時にローカルの `draggableQueue` を同期

### `tests/unit/queueStore.test.ts`（新規）
- `moveSong` の `currentIndex` 補正ロジック 7 ケース
- `totalDuration` 3 ケース

## 受け入れ条件チェック

- [x] QueueDrawer で曲順を変更できる（ドラッグ操作）
- [x] 並び替え後も現在再生中の曲が正しく維持される（`moveSong` の補正ロジック）
- [x] 現在位置が視覚的に分かりやすい（emerald 色 + 再生中アイコン）
- [x] 削除、ジャンプ、クリアなど既存操作が壊れない
