### PR TITLE
feat: iOS user-gesture chain 対応 — requestPlay() 明示的再生 API を実装

### DIFF
--- a/app/components/PlayerBar.vue
+++ b/app/components/PlayerBar.vue
@@ -21,8 +21,23 @@
             <path d="M6 6h2v12H6V6zm3.5 6l8.5 6V6l-8.5 6z" />
           </svg>
         </button>
-        <button class="text-gray-400 hover:text-white" @click="playback.togglePlay()">
-          <svg class="h-8 w-8" fill="currentColor" viewBox="0 0 24 24">
+        <button
+          class="text-gray-400 hover:text-white"
+          :title="player.isBlocked ? '再生がブロックされました。タップして再試行' : undefined"
+          @click="handleMobilePlay"
+        >
+          <!-- Blocked: show retry icon -->
+          <svg
+            v-if="player.isBlocked"
+            class="h-8 w-8 text-emerald-400"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+            />
+          </svg>
+          <svg v-else class="h-8 w-8" fill="currentColor" viewBox="0 0 24 24">
             <path v-if="player.isPlaying" d="M6 4h4v16H6V4zm8 0h4v16h-4V4z" />
             <path v-else d="M8 5v14l11-7z" />
           </svg>
@@ -98,9 +113,16 @@
           <!-- Play/Pause -->
           <button
             class="flex h-9 w-9 items-center justify-center bg-emerald-500 text-white hover:bg-emerald-400"
-            @click="playback.togglePlay()"
+            :title="player.isBlocked ? '再生がブロックされました。タップして再試行' : undefined"
+            @click="handleDesktopPlay"
           >
-            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+            <!-- Blocked: show retry icon -->
+            <svg v-if="player.isBlocked" class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+              <path
+                d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+              />
+            </svg>
+            <svg v-else class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
               <path v-if="player.isPlaying" d="M6 4h4v16H6V4zm8 0h4v16h-4V4z" />
               <path v-else d="M8 5v14l11-7z" />
             </svg>
@@ -228,6 +250,7 @@ const player = usePlayerStore()
 const queue = useQueueStore()
 const playback = usePlayback()
 const { formatTime, songDuration } = useFormatTime()
+const { seekTo, retryPlay } = useYouTubePlayer()
 
 const progressPercent = computed(() => {
   const song = player.currentSong
@@ -238,6 +261,16 @@ const progressPercent = computed(() => {
   return Math.min(100, Math.max(0, (elapsed / duration) * 100))
 })
 
+function handleMobilePlay() {
+  if (player.isBlocked) retryPlay()
+  else playback.togglePlay()
+}
+
+function handleDesktopPlay() {
+  if (player.isBlocked) retryPlay()
+  else playback.togglePlay()
+}
+
 function handleSeek(e: MouseEvent) {
   const song = player.currentSong
   if (!song) return
@@ -246,7 +279,6 @@ function handleSeek(e: MouseEvent) {
   const percent = (e.clientX - rect.left) / rect.width
   const duration = song.end_at - song.start_at
   const seekTime = song.start_at + duration * percent
-  const { seekTo } = useYouTubePlayer()
   seekTo(seekTime)
 }
 </script>

--- a/app/components/QueueDrawer.vue
+++ b/app/components/QueueDrawer.vue
@@ -267,7 +267,10 @@ function handleDragEnd(event: { oldIndex: number; newIndex: number }) {
 function jumpTo(index: number) {
   queue.currentIndex = index
   const song = queue.currentSong
-  if (song) player.play(song)
+  if (!song) return
+  player.play(song)
+  const { requestPlay } = useYouTubePlayer()
+  requestPlay(song)
 }
 </script>
 

--- a/app/components/YouTubeEmbed.vue
+++ b/app/components/YouTubeEmbed.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="hidden">
+  <!--
+    Positioned off-screen rather than display:none / 0×0.
+    display:none prevents the browser from rendering the iframe at all, which
+    can interfere with iOS WKWebView media playback.  1px off-screen keeps the
+    element in the layout without being visible.
+  -->
+  <div
+    style="position: fixed; top: -9999px; left: -9999px; width: 1px; height: 1px; overflow: hidden"
+  >
     <div id="yt-player" />
   </div>
 </template>

--- a/app/composables/usePlayback.ts
+++ b/app/composables/usePlayback.ts
@@ -1,21 +1,34 @@
 export function usePlayback() {
   const player = usePlayerStore()
   const queue = useQueueStore()
+  const { resumePlay, pausePlay, requestPlay } = useYouTubePlayer()
 
   function togglePlay() {
-    if (player.isPlaying) player.pause()
-    else player.resume()
+    if (player.isPlaying) {
+      player.pause()
+      pausePlay()
+    } else {
+      player.resume()
+      resumePlay()
+    }
   }
 
   function nextSong() {
     const song = queue.next()
-    if (song) player.play(song)
-    else player.stop()
+    if (song) {
+      player.play(song)
+      requestPlay(song)
+    } else {
+      player.stop()
+    }
   }
 
   function previousSong() {
     const song = queue.previous()
-    if (song) player.play(song)
+    if (song) {
+      player.play(song)
+      requestPlay(song)
+    }
   }
 
   return { togglePlay, nextSong, previousSong }

--- a/app/composables/useQueueActions.ts
+++ b/app/composables/useQueueActions.ts
@@ -3,18 +3,24 @@ import type { Song } from '~/types'
 export function useQueueActions() {
   const player = usePlayerStore()
   const queue = useQueueStore()
+  const { requestPlay } = useYouTubePlayer()
 
   /** Replace queue and play from a specific index */
   function playAll(songs: Song[], startIndex = 0) {
     queue.setSongs(songs, startIndex)
     const current = queue.currentSong
-    if (current) player.play(current)
+    if (!current) return
+    player.play(current)
+    // Call requestPlay synchronously within the user-gesture chain.
+    requestPlay(current)
   }
 
   /** Replace queue with a single song and play it */
   function playSong(song: Song) {
     queue.setSongs([song], 0)
     player.play(song)
+    // Call requestPlay synchronously within the user-gesture chain.
+    requestPlay(song)
   }
 
   /** Insert as next in queue */

--- a/app/composables/useYouTubePlayer.ts
+++ b/app/composables/useYouTubePlayer.ts
@@ -1,9 +1,27 @@
+import type { Song } from '~/types'
+
+// ---------------------------------------------------------------------------
+// Module-level singleton state
+// All calls to useYouTubePlayer() share these variables so that the player
+// instance initialised by YouTubeEmbed.vue is the same one used by
+// PlayerBar.vue, useQueueActions, etc.
+// ---------------------------------------------------------------------------
+
+let ytPlayer: YT.Player | null = null
+/** True once the IFrame API + player element are fully ready. */
+const ready = ref(false)
+
+/** Play request queued before the player was ready. */
+let pendingRequest: { videoId: string; startSeconds: number; endSeconds?: number } | null = null
+
+let intervalId: ReturnType<typeof setInterval> | null = null
+
+// ---------------------------------------------------------------------------
+
 export function useYouTubePlayer() {
   const player = usePlayerStore()
 
-  const ready = ref(false)
-  let ytPlayer: YT.Player | null = null
-  let intervalId: ReturnType<typeof setInterval> | null = null
+  // --- API loader ------------------------------------------------------------
 
   function loadApi(): Promise<void> {
     return new Promise((resolve) => {
@@ -18,32 +36,79 @@ export function useYouTubePlayer() {
     })
   }
 
+  // --- Initialisation -------------------------------------------------------
+
   async function initPlayer(elementId: string) {
     await loadApi()
+    const origin = window.location.origin
     ytPlayer = new window.YT.Player(elementId, {
-      height: '0',
-      width: '0',
+      height: '1',
+      width: '1',
       playerVars: {
         autoplay: 0,
         controls: 0,
         disablekb: 1,
         fs: 0,
         rel: 0,
+        // Required for inline playback on iOS (prevents fullscreen takeover).
+        playsinline: 1,
+        // Recommended by YouTube docs; reduces cross-origin issues.
+        origin,
       },
       events: {
-        onReady: () => {
-          ready.value = true
-        },
+        onReady: handleReady,
         onStateChange: handleStateChange,
+        onError: handleError,
+        onAutoplayBlocked: handleAutoplayBlocked,
       },
     })
   }
 
+  // --- Event handlers -------------------------------------------------------
+
+  function handleReady() {
+    ready.value = true
+    // If a play request arrived while the player was still initialising,
+    // fulfil it now (note: this is not within the original user gesture, so
+    // iOS may still block it — the UI will show a retry button in that case).
+    if (pendingRequest) {
+      const req = pendingRequest
+      pendingRequest = null
+      _loadAndPlay(req)
+    }
+  }
+
   function handleStateChange(event: YT.OnStateChangeEvent) {
-    // YT.PlayerState.ENDED === 0
-    if (event.data === 0) {
+    const state = event.data
+    if (state === 1 /* PLAYING */) {
+      player.setPlaying(true)
+      startTimeTracking()
+    } else if (state === 2 /* PAUSED */) {
+      player.setPlaying(false)
+      stopTimeTracking()
+    } else if (state === 0 /* ENDED */) {
+      stopTimeTracking()
       onSongEnd()
     }
+  }
+
+  function handleError(event: { data: number }) {
+    console.error('[YouTubePlayer] error code:', event.data)
+    player.setPlaying(false)
+  }
+
+  function handleAutoplayBlocked() {
+    // Browser blocked scripted / autoplay playback (common on iOS/desktop).
+    player.setBlocked()
+  }
+
+  // --- Internal helpers -----------------------------------------------------
+
+  function _loadAndPlay(config: { videoId: string; startSeconds: number; endSeconds?: number }) {
+    if (!ytPlayer) return
+    // loadVideoById triggers autoplay on desktop; on iOS it may be blocked.
+    ytPlayer.loadVideoById(config)
+    startTimeTracking()
   }
 
   function onSongEnd() {
@@ -54,14 +119,12 @@ export function useYouTubePlayer() {
   function startTimeTracking() {
     stopTimeTracking()
     intervalId = setInterval(() => {
-      if (ytPlayer && player.isPlaying) {
-        const time = ytPlayer.getCurrentTime()
-        player.updateTime(time)
-
-        const song = player.currentSong
-        if (song && song.end_at > 0 && time >= song.end_at) {
-          onSongEnd()
-        }
+      if (!ytPlayer || !player.isPlaying) return
+      const time = ytPlayer.getCurrentTime()
+      player.updateTime(time)
+      const song = player.currentSong
+      if (song && song.end_at > 0 && time >= song.end_at) {
+        onSongEnd()
       }
     }, 500)
   }
@@ -71,6 +134,52 @@ export function useYouTubePlayer() {
       clearInterval(intervalId)
       intervalId = null
     }
+  }
+
+  // --- Public API -----------------------------------------------------------
+
+  /**
+   * Primary play request — call this directly from a user-gesture handler
+   * (click / tap) so that the synchronous call to loadVideoById() stays
+   * within the iOS user-gesture chain.
+   *
+   * If the player is not yet ready, the request is queued and processed in
+   * onReady().
+   */
+  function requestPlay(song: Song) {
+    player.clearBlocked()
+    const config = {
+      videoId: song.video.id,
+      startSeconds: song.start_at,
+      endSeconds: song.end_at > 0 ? song.end_at : undefined,
+    }
+    if (!ready.value || !ytPlayer) {
+      pendingRequest = config
+      return
+    }
+    _loadAndPlay(config)
+  }
+
+  /** Resume the current video (e.g. from play/pause toggle). */
+  function resumePlay() {
+    if (!ytPlayer) return
+    player.clearBlocked()
+    ytPlayer.playVideo()
+  }
+
+  /** Pause the current video. */
+  function pausePlay() {
+    ytPlayer?.pauseVideo()
+  }
+
+  /**
+   * Retry after autoplay was blocked.  Must be called from a user-gesture
+   * handler so that the gesture chain is preserved.
+   */
+  function retryPlay() {
+    const song = player.currentSong
+    if (!song) return
+    requestPlay(song)
   }
 
   function seekTo(seconds: number) {
@@ -83,33 +192,12 @@ export function useYouTubePlayer() {
     ytPlayer?.destroy()
     ytPlayer = null
     ready.value = false
+    pendingRequest = null
   }
 
-  // Watch currentSong — load video when song changes
-  watch(
-    () => player.currentSong,
-    (song) => {
-      if (!song || !ytPlayer) return
-      ytPlayer.loadVideoById({
-        videoId: song.video.id,
-        startSeconds: song.start_at,
-        endSeconds: song.end_at > 0 ? song.end_at : undefined,
-      })
-      startTimeTracking()
-    },
-  )
+  // --- Passive watchers (volume / mute) -------------------------------------
+  // These do not affect the user-gesture chain so watch-based is fine.
 
-  // Watch play/pause state
-  watch(
-    () => player.isPlaying,
-    (playing) => {
-      if (!ytPlayer) return
-      if (playing) ytPlayer.playVideo()
-      else ytPlayer.pauseVideo()
-    },
-  )
-
-  // Watch volume
   watch(
     () => player.volume,
     (vol) => {
@@ -117,7 +205,6 @@ export function useYouTubePlayer() {
     },
   )
 
-  // Watch mute
   watch(
     () => player.isMuted,
     (muted) => {
@@ -129,6 +216,10 @@ export function useYouTubePlayer() {
   return {
     ready: readonly(ready),
     initPlayer,
+    requestPlay,
+    resumePlay,
+    pausePlay,
+    retryPlay,
     seekTo,
     destroy,
   }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -54,8 +54,11 @@ useHead({ title: 'inuinouta' })
 const { songs: randomSongs, status: randomStatus, refresh: randomRefresh } = useRandomSongs(10)
 
 const { useApiFetch } = useApi()
-const { data: recentResponse, status: recentStatus } = await useApiFetch<SongsResponse>('/api/songs/', {
-  query: { page: 1, per_page: 10, 'sort[]': '-video.published_at' },
-})
+const { data: recentResponse, status: recentStatus } = await useApiFetch<SongsResponse>(
+  '/api/songs/',
+  {
+    query: { page: 1, per_page: 10, 'sort[]': '-video.published_at' },
+  },
+)
 const recentSongs = computed(() => recentResponse.value?.songs ?? [])
 </script>

--- a/app/stores/player.ts
+++ b/app/stores/player.ts
@@ -3,14 +3,18 @@ import type { Song } from '~/types'
 export const usePlayerStore = defineStore('player', () => {
   const currentSong = ref<Song | null>(null)
   const isPlaying = ref(false)
+  /** True when the browser blocked autoplay / scripted playback */
+  const isBlocked = ref(false)
   const currentTime = ref(0)
   const duration = ref(0)
   const volume = ref(100)
   const isMuted = ref(false)
 
+  /** Set current song and optimistically mark as playing (UI feedback). */
   function play(song: Song) {
     currentSong.value = song
     isPlaying.value = true
+    isBlocked.value = false
   }
 
   function pause() {
@@ -25,6 +29,23 @@ export const usePlayerStore = defineStore('player', () => {
     isPlaying.value = false
     currentTime.value = 0
     currentSong.value = null
+    isBlocked.value = false
+  }
+
+  /** Sync isPlaying with the actual YouTube player state. */
+  function setPlaying(value: boolean) {
+    isPlaying.value = value
+    if (value) isBlocked.value = false
+  }
+
+  /** Mark playback as blocked by the browser autoplay policy. */
+  function setBlocked() {
+    isBlocked.value = true
+    isPlaying.value = false
+  }
+
+  function clearBlocked() {
+    isBlocked.value = false
   }
 
   function setVolume(value: number) {
@@ -46,6 +67,7 @@ export const usePlayerStore = defineStore('player', () => {
   return {
     currentSong,
     isPlaying,
+    isBlocked,
     currentTime,
     duration,
     volume,
@@ -54,6 +76,9 @@ export const usePlayerStore = defineStore('player', () => {
     pause,
     resume,
     stop,
+    setPlaying,
+    setBlocked,
+    clearBlocked,
     setVolume,
     toggleMute,
     updateTime,

--- a/app/types/youtube.d.ts
+++ b/app/types/youtube.d.ts
@@ -8,6 +8,8 @@ declare namespace YT {
       onReady?: (event: { target: Player }) => void
       onStateChange?: (event: OnStateChangeEvent) => void
       onError?: (event: { data: number }) => void
+      /** Fired when the browser blocks autoplay / scripted playback (iOS / desktop policy). */
+      onAutoplayBlocked?: () => void
     }
   }
 


### PR DESCRIPTION
## 概要

iOS Safari / Chrome（WebKit）のメディア再生制約（user-gesture chain）により、`watch` 起点の暗黙的 `loadVideoById()` が常にブロックされ、SongCard をタップしても再生が始まらない問題を根本から改修します。

Closes #14

---

## 根本原因

| 問題 | 詳細 |
|---|---|
| watch 起点の再生 | `player.currentSong` の変化を `watch` で検知して `ytPlayer.loadVideoById()` を呼んでいたが、watch コールバックはユーザージェスチャーのコールスタック外で実行される |
| iOS WKWebView の制約 | user-gesture chain 外の `play()` / `loadVideoById()` は silently blocked |
| 0×0 要素問題 | `height: '0', width: '0'` の iframe も WKWebView が再生をブロックするケースがある |
| 別インスタンス問題 | `useYouTubePlayer()` が呼ぶたびに別の reactive スコープを返し、`PlayerBar.vue` の `seekTo()` が別インスタンスを参照していた |

---

## 変更内容

### `useYouTubePlayer.ts`（全面改修）
- `ytPlayer` / `ready` / `pendingRequest` をモジュールレベルシングルトンに変更（複数コンポーネントから同一インスタンスを共有）
- **`requestPlay(song)`** を追加 — ユーザーイベントハンドラから同期呼び出しすることで user-gesture chain を保持
- 未初期化時は `pendingRequest` に保持し `handleReady()` で再試行（race condition を解消）
- `onAutoplayBlocked` ハンドラで `player.setBlocked()` を呼ぶ
- `handleStateChange()` で PLAYING(1)/PAUSED(2)/ENDED(0) をストアへ同期
- 再生制御の `watch` を全廃し `resumePlay()` / `pausePlay()` に置き換え

### `stores/player.ts`
- `isBlocked = ref(false)` を追加（autoplay がブロックされた状態を UI に伝達）
- `setBlocked()` / `clearBlocked()` / `setPlaying()` アクションを追加

### `YouTubeEmbed.vue`
- `display:none` / 0×0 サイズ → `position: fixed; top: -9999px; left: -9999px; width: 1px; height: 1px` のオフスクリーン配置に変更（iOS WKWebView の再生条件を満たす）

### `useQueueActions.ts` / `usePlayback.ts`
- `playSong()` / `playAll()` / `nextSong()` / `previousSong()` で `player.play()`（UI 楽観的更新）と `requestPlay()`（YouTube 実制御）を同期的に呼び出すよう変更

### `QueueDrawer.vue`
- `jumpTo()` に `requestPlay()` を追加（`watch` 廃止後に機能喪失していた再生制御を復元）

### `PlayerBar.vue`
- `isBlocked` 時に再試行アイコンを表示し `retryPlay()` を呼ぶ（モバイル・デスクトップ両対応）

---

## 再生トリガーパス 全 10 経路の確認結果

| トリガー | 経路 | `requestPlay()` |
|---|---|---|
| SongCard クリック | `useQueueActions.playSong()` | ✅ |
| SongListItem クリック | `useQueueActions.playSong()` | ✅ |
| songs/index 全件再生 | `useQueueActions.playAll()` | ✅ |
| songs/[id] 単曲再生 | `useQueueActions.playSong()` | ✅ |
| videos/[id] 全件再生 | `useQueueActions.playAll()` | ✅ |
| videos/[id] 個別曲再生 | `useQueueActions.playAll(songs, index)` | ✅ |
| QueueDrawer jumpTo | 直接 `requestPlay()` 呼び出し | ✅ |
| PlayerBar 再生/一時停止 | `usePlayback.togglePlay()` → `resumePlay()`/`pausePlay()` | ✅ |
| PlayerBar 次の曲 | `usePlayback.nextSong()` → `requestPlay()` | ✅ |
| PlayerBar 前の曲 | `usePlayback.previousSong()` → `requestPlay()` | ✅ |

---

## テスト

- ユニットテスト: 54/54 pass
- Playwright E2E: キュー操作全経路（jumpTo・next/previous・playAll・playSong）を手動確認済み