### PR TITLE
[videos] モバイルの動画一覧を2カラム表示に最適化する

### DIFF
--- a/app/components/VideoCard.vue
+++ b/app/components/VideoCard.vue
@@ -30,9 +30,11 @@
     </div>
 
     <!-- Info -->
-    <div class="p-3">
-      <p class="line-clamp-2 text-sm font-medium" :title="video.title">{{ video.title }}</p>
-      <p class="mt-1 text-xs text-gray-500">
+    <div class="p-2 sm:p-3">
+      <p class="line-clamp-2 text-xs font-medium sm:text-sm" :title="video.title">
+        {{ video.title }}
+      </p>
+      <p class="mt-0.5 text-xs text-gray-500 sm:mt-1">
         {{ formatDate(video.published_at) }}
       </p>
     </div>

--- a/app/pages/videos/index.vue
+++ b/app/pages/videos/index.vue
@@ -3,12 +3,18 @@
     <h1 class="mb-6 text-xl font-bold">動画一覧</h1>
 
     <!-- Loading -->
-    <div v-if="status === 'pending'" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      <div v-for="n in 9" :key="n" class="aspect-video animate-pulse bg-surface-raised" />
+    <div v-if="status === 'pending'" class="grid grid-cols-2 gap-3 lg:grid-cols-3">
+      <div v-for="n in 9" :key="n" class="border border-border-default bg-surface-raised">
+        <div class="aspect-video animate-pulse bg-surface-overlay" />
+        <div class="p-2 sm:p-3">
+          <div class="h-3 animate-pulse bg-surface-overlay" />
+          <div class="mt-1 h-2.5 w-1/2 animate-pulse bg-surface-overlay" />
+        </div>
+      </div>
     </div>
 
     <!-- Video grid -->
-    <div v-else class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div v-else class="grid grid-cols-2 gap-3 lg:grid-cols-3">
       <VideoCard v-for="video in videos" :key="video.id" :video="video" />
     </div>
 


### PR DESCRIPTION
## 変更概要

Issue #17 の対応です。モバイルの動画一覧を 2 カラム表示に最適化しました。

## 変更内容

### `app/pages/videos/index.vue`
- グリッドクラスを `grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3` から `grid-cols-2 gap-3 lg:grid-cols-3` に変更してモバイルから常時 2 カラム表示に
- ローディング skeleton にテキストプレースホルダー（タイトル・日付）を追加し、コンテンツ表示時のレイアウトシフトを軽減

### `app/components/VideoCard.vue`
- padding: `p-3` → `p-2 sm:p-3`（モバイル向けに縮小）
- タイトルフォント: `text-sm` → `text-xs sm:text-sm`（モバイル向けに縮小、`font-medium` で可読性は維持）
- 日付マージン: `mt-1` → `mt-0.5 sm:mt-1`（パディング縮小に合わせて調整）

## 受け入れ条件の確認

- [x] モバイル幅で動画一覧が 2 カラム表示になる
- [x] ローディング中の skeleton も同じ列構成で表示される（テキストプレースホルダー付き）
- [x] カードのタイトルや日付が極端に読みにくくならない（`font-medium` を維持）
- [x] タブレットとデスクトップの既存表示が維持される（`lg:grid-cols-3` 変更なし）

## デザイン原則との整合

- 角丸なし ✓
- ダークモード専用 ✓（`bg-surface-raised`, `bg-surface-overlay`, `border-border-default`）
- emerald アクセントカラー ✓（ホバー時の `border-emerald-500/40` に変更なし）

Closes #17