### PR TITLE
feat: Local-first プレイリスト実装 #23

### DIFF
--- a/app/components/AddToPlaylistDropdown.vue
+++ b/app/components/AddToPlaylistDropdown.vue
@@ -1,0 +1,155 @@
+<template>
+  <div class="relative" :class="{ 'dropdown-open': open }">
+    <button
+      class="p-1 text-gray-400 hover:text-white"
+      title="プレイリストに追加"
+      @click.stop="toggle"
+    >
+      <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+        />
+      </svg>
+    </button>
+
+    <div
+      v-if="open"
+      class="absolute right-0 top-full z-50 mt-1 w-52 border border-border-default bg-surface-raised shadow-lg"
+      @click.stop
+    >
+      <!-- Create mode: inline name input -->
+      <template v-if="isCreating">
+        <div class="p-3">
+          <p class="mb-1.5 text-xs text-gray-400">新規プレイリスト名</p>
+          <input
+            ref="createInput"
+            v-model="newName"
+            class="w-full border border-border-default bg-surface-overlay px-2 py-1 text-xs text-gray-50 focus:border-accent focus:outline-none"
+            placeholder="名前を入力"
+            maxlength="100"
+            @keydown.enter="handleCreate"
+            @keydown.escape="open = false"
+          />
+          <div class="mt-2 flex justify-end gap-3">
+            <button class="text-xs text-gray-400 hover:text-white" @click="open = false">
+              キャンセル
+            </button>
+            <button
+              class="text-xs text-emerald-400 hover:text-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
+              :disabled="!newName.trim()"
+              @click="handleCreate"
+            >
+              作成して追加
+            </button>
+          </div>
+        </div>
+      </template>
+
+      <!-- List mode: existing playlists -->
+      <template v-else>
+        <div v-if="playlists.length === 0" class="px-3 py-3 text-center text-xs text-gray-400">
+          プレイリストがありません
+        </div>
+        <button
+          v-for="pl in playlists"
+          :key="pl.id"
+          class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-surface-overlay"
+          @click="addTo(pl.id)"
+        >
+          <span
+            class="flex-1 truncate"
+            :class="addedId === pl.id ? 'text-emerald-400' : 'text-gray-50'"
+          >
+            {{ pl.name }}
+          </span>
+          <svg
+            v-if="addedId === pl.id"
+            class="h-3.5 w-3.5 shrink-0 text-emerald-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2.5"
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        </button>
+        <div class="border-t border-border-default">
+          <button
+            class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-gray-400 hover:bg-surface-overlay hover:text-white"
+            @click="isCreating = true"
+          >
+            <svg class="h-3.5 w-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            新規プレイリスト
+          </button>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ songId: number }>()
+
+const playlistsStore = usePlaylistsStore()
+const open = ref(false)
+const isCreating = ref(false)
+const newName = ref('')
+const addedId = ref<string | null>(null)
+const createInput = ref<HTMLInputElement | null>(null)
+
+const playlists = computed(() => playlistsStore.playlists)
+
+function toggle() {
+  open.value = !open.value
+  if (open.value) {
+    playlistsStore.loadFromStorage()
+    isCreating.value = false
+  }
+}
+
+function addTo(playlistId: string) {
+  playlistsStore.addSong(playlistId, props.songId)
+  addedId.value = playlistId
+  setTimeout(() => {
+    open.value = false
+    addedId.value = null
+  }, 1000)
+}
+
+function handleCreate() {
+  const name = newName.value.trim()
+  if (!name) return
+  const created = playlistsStore.createPlaylist(name, '', [props.songId])
+  addedId.value = created.id
+  isCreating.value = false
+  newName.value = ''
+  setTimeout(() => {
+    open.value = false
+    addedId.value = null
+  }, 1000)
+}
+
+watch(isCreating, (val) => {
+  if (val) nextTick(() => createInput.value?.focus())
+})
+
+function handleOutsideClick() {
+  open.value = false
+}
+onMounted(() => document.addEventListener('click', handleOutsideClick))
+onBeforeUnmount(() => document.removeEventListener('click', handleOutsideClick))
+</script>

--- a/app/components/QueueDrawer.vue
+++ b/app/components/QueueDrawer.vue
@@ -17,6 +17,13 @@
           </span>
         </div>
         <div class="flex items-center gap-2">
+          <button
+            v-if="queue.songs.length > 0"
+            class="text-xs text-gray-400 hover:text-white"
+            @click="isSaving = true"
+          >
+            保存
+          </button>
           <button class="text-xs text-gray-400 hover:text-white" @click="queue.clear()">
             クリア
           </button>
@@ -31,6 +38,83 @@
             </svg>
           </button>
         </div>
+      </div>
+
+      <!-- Save as playlist panel -->
+      <div v-if="isSaving" class="border-b border-border-default">
+        <!-- Tab header -->
+        <div class="flex items-center gap-4 border-b border-border-default px-4 py-2">
+          <button
+            class="text-xs"
+            :class="
+              saveMode === 'new' ? 'font-medium text-gray-50' : 'text-gray-400 hover:text-white'
+            "
+            @click="saveMode = 'new'"
+          >
+            新規作成
+          </button>
+          <button
+            class="text-xs"
+            :class="
+              saveMode === 'existing'
+                ? 'font-medium text-gray-50'
+                : 'text-gray-400 hover:text-white'
+            "
+            @click="saveMode = 'existing'"
+          >
+            既存に追加
+          </button>
+          <button class="ml-auto text-xs text-gray-400 hover:text-white" @click="cancelSave">
+            ✕
+          </button>
+        </div>
+        <!-- New: name input -->
+        <div v-if="saveMode === 'new'" class="flex items-center gap-2 px-4 py-2">
+          <input
+            ref="saveInputDesktop"
+            v-model="saveName"
+            class="flex-1 border border-border-default bg-surface-overlay px-2 py-1 text-sm text-gray-50 focus:border-accent focus:outline-none"
+            placeholder="プレイリスト名"
+            maxlength="100"
+            @keydown.enter="handleSaveAsPlaylist"
+            @keydown.escape="cancelSave"
+          />
+          <button
+            class="text-xs text-emerald-400 hover:text-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="!saveName.trim()"
+            @click="handleSaveAsPlaylist"
+          >
+            保存
+          </button>
+        </div>
+        <!-- Existing: playlist list -->
+        <div v-else class="max-h-44 overflow-y-auto">
+          <div v-if="playlistsStore.playlists.length === 0" class="px-4 py-3 text-xs text-gray-400">
+            まだプレイリストがありません
+          </div>
+          <button
+            v-for="pl in playlistsStore.playlists"
+            :key="pl.id"
+            class="flex w-full items-center gap-2 px-4 py-2 text-left text-xs hover:bg-surface-overlay"
+            @click="handleAddToExistingPlaylist(pl)"
+          >
+            <span class="flex-1 truncate text-gray-50">{{ pl.name }}</span>
+            <span class="text-gray-500">{{ pl.items.length }}曲</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Save confirmation -->
+      <div v-if="saveMessage" class="border-b border-border-default px-4 py-2 text-xs">
+        <span class="text-emerald-400">{{ saveMessage }}</span>
+        <NuxtLink
+          v-if="savedPlaylistId"
+          :to="`/playlists/${savedPlaylistId}`"
+          class="ml-2 text-emerald-400 underline hover:text-emerald-300"
+          @click="queue.toggleOpen()"
+        >
+          開く
+        </NuxtLink>
       </div>
 
       <!-- Queue list -->
@@ -133,6 +217,13 @@
             </span>
           </div>
           <div class="flex items-center gap-2">
+            <button
+              v-if="queue.songs.length > 0"
+              class="text-xs text-gray-400 hover:text-white"
+              @click="isSaving = true"
+            >
+              保存
+            </button>
             <button class="text-xs text-gray-400 hover:text-white" @click="queue.clear()">
               クリア
             </button>
@@ -147,6 +238,86 @@
               </svg>
             </button>
           </div>
+        </div>
+
+        <!-- Save as playlist panel (mobile) -->
+        <div v-if="isSaving" class="border-b border-border-default">
+          <!-- Tab header -->
+          <div class="flex items-center gap-4 border-b border-border-default px-4 py-2">
+            <button
+              class="text-xs"
+              :class="
+                saveMode === 'new' ? 'font-medium text-gray-50' : 'text-gray-400 hover:text-white'
+              "
+              @click="saveMode = 'new'"
+            >
+              新規作成
+            </button>
+            <button
+              class="text-xs"
+              :class="
+                saveMode === 'existing'
+                  ? 'font-medium text-gray-50'
+                  : 'text-gray-400 hover:text-white'
+              "
+              @click="saveMode = 'existing'"
+            >
+              既存に追加
+            </button>
+            <button class="ml-auto text-xs text-gray-400 hover:text-white" @click="cancelSave">
+              ✕
+            </button>
+          </div>
+          <!-- New: name input -->
+          <div v-if="saveMode === 'new'" class="flex items-center gap-2 px-4 py-2">
+            <input
+              ref="saveInputMobile"
+              v-model="saveName"
+              class="flex-1 border border-border-default bg-surface-overlay px-2 py-1 text-sm text-gray-50 focus:border-accent focus:outline-none"
+              placeholder="プレイリスト名"
+              maxlength="100"
+              @keydown.enter="handleSaveAsPlaylist"
+              @keydown.escape="cancelSave"
+            />
+            <button
+              class="text-xs text-emerald-400 hover:text-emerald-300 disabled:cursor-not-allowed disabled:opacity-50"
+              :disabled="!saveName.trim()"
+              @click="handleSaveAsPlaylist"
+            >
+              保存
+            </button>
+          </div>
+          <!-- Existing: playlist list -->
+          <div v-else class="max-h-44 overflow-y-auto">
+            <div
+              v-if="playlistsStore.playlists.length === 0"
+              class="px-4 py-3 text-xs text-gray-400"
+            >
+              まだプレイリストがありません
+            </div>
+            <button
+              v-for="pl in playlistsStore.playlists"
+              :key="pl.id"
+              class="flex w-full items-center gap-2 px-4 py-2 text-left text-xs hover:bg-surface-overlay"
+              @click="handleAddToExistingPlaylist(pl)"
+            >
+              <span class="flex-1 truncate text-gray-50">{{ pl.name }}</span>
+              <span class="text-gray-500">{{ pl.items.length }}曲</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Save confirmation (mobile) -->
+        <div v-if="saveMessage" class="border-b border-border-default px-4 py-2 text-xs">
+          <span class="text-emerald-400">{{ saveMessage }}</span>
+          <NuxtLink
+            v-if="savedPlaylistId"
+            :to="`/playlists/${savedPlaylistId}`"
+            class="ml-2 text-emerald-400 underline hover:text-emerald-300"
+            @click="queue.toggleOpen()"
+          >
+            開く
+          </NuxtLink>
         </div>
 
         <!-- Queue list -->
@@ -245,10 +416,11 @@
 
 <script setup lang="ts">
 import { VueDraggableNext } from 'vue-draggable-next'
-import type { Song } from '~/types'
+import type { Song, LocalPlaylist } from '~/types'
 
 const queue = useQueueStore()
 const player = usePlayerStore()
+const playlistsStore = usePlaylistsStore()
 
 const draggableQueue = ref<Song[]>([])
 
@@ -271,6 +443,67 @@ function jumpTo(index: number) {
   player.play(song)
   const { requestPlay } = useYouTubePlayer()
   requestPlay(song)
+}
+
+// Save as playlist
+const isSaving = ref(false)
+const saveMode = ref<'new' | 'existing'>('new')
+const saveName = ref('')
+const saveMessage = ref('')
+const savedPlaylistId = ref<string | null>(null)
+const saveInputDesktop = ref<HTMLInputElement | null>(null)
+const saveInputMobile = ref<HTMLInputElement | null>(null)
+
+watch(isSaving, (val) => {
+  if (val) {
+    saveMode.value = 'new'
+    playlistsStore.loadFromStorage()
+    nextTick(() => {
+      saveInputDesktop.value?.focus()
+      saveInputMobile.value?.focus()
+    })
+  }
+})
+
+watch(saveMode, (mode) => {
+  if (mode === 'new') {
+    nextTick(() => {
+      saveInputDesktop.value?.focus()
+      saveInputMobile.value?.focus()
+    })
+  }
+})
+
+function handleSaveAsPlaylist() {
+  const name = saveName.value.trim()
+  if (!name || queue.songs.length === 0) return
+  const songIds = queue.songs.map((s) => s.id)
+  const created = playlistsStore.createPlaylist(name, '', songIds)
+  savedPlaylistId.value = created.id
+  saveName.value = ''
+  isSaving.value = false
+  saveMessage.value = `「${name}」を保存しました`
+  setTimeout(() => {
+    saveMessage.value = ''
+    savedPlaylistId.value = null
+  }, 5000)
+}
+
+function handleAddToExistingPlaylist(pl: LocalPlaylist) {
+  const songIds = queue.songs.map((s) => s.id)
+  playlistsStore.addSongs(pl.id, songIds)
+  isSaving.value = false
+  savedPlaylistId.value = pl.id
+  saveMessage.value = `「${pl.name}」に${songIds.length}曲を追加しました`
+  setTimeout(() => {
+    saveMessage.value = ''
+    savedPlaylistId.value = null
+  }, 5000)
+}
+
+function cancelSave() {
+  saveName.value = ''
+  isSaving.value = false
 }
 </script>
 

--- a/app/components/SongListItem.vue
+++ b/app/components/SongListItem.vue
@@ -40,8 +40,10 @@
 
     <!-- Actions -->
     <div
-      class="flex shrink-0 gap-1 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+      class="flex shrink-0 gap-1 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:[&:has(.dropdown-open)]:opacity-100"
     >
+      <slot name="extra-actions" />
+      <AddToPlaylistDropdown :song-id="song.id" />
       <button
         class="p-1 text-gray-400 hover:text-white"
         title="次に再生"

--- a/app/composables/usePlaylistDetail.ts
+++ b/app/composables/usePlaylistDetail.ts
@@ -1,0 +1,58 @@
+import type { Song, SongsResponse } from '~/types'
+
+export function usePlaylistDetail(playlistId: string) {
+  const playlistsStore = usePlaylistsStore()
+  const { $api } = useApi()
+
+  const songs = ref<Song[]>([])
+  const status = ref<'idle' | 'pending' | 'ready' | 'error'>('idle')
+
+  const playlist = computed(() => playlistsStore.getById(playlistId))
+
+  async function fetchSongs() {
+    const pl = playlist.value
+    if (!pl || pl.items.length === 0) {
+      songs.value = []
+      status.value = 'ready'
+      return
+    }
+
+    status.value = 'pending'
+    try {
+      const songIds = pl.items.map((item) => item.song_id)
+      const params = new URLSearchParams()
+      songIds.forEach((id) => params.append('filter{id.in}', String(id)))
+      params.set('per_page', String(songIds.length))
+
+      const res = await $api<SongsResponse>(`/api/songs/?${params.toString()}`)
+      const fetchedSongs = res.songs
+
+      // Sort by playlist item order
+      songs.value = pl.items
+        .map((item) => fetchedSongs.find((s) => s.id === item.song_id))
+        .filter((s): s is Song => s !== undefined)
+
+      status.value = 'ready'
+    } catch {
+      status.value = 'error'
+    }
+  }
+
+  const totalDuration = computed(() => {
+    const totalSeconds = songs.value.reduce((sum, song) => {
+      return sum + Math.max(0, song.end_at - song.start_at)
+    }, 0)
+    const hours = Math.floor(totalSeconds / 3600)
+    const minutes = Math.floor((totalSeconds % 3600) / 60)
+    if (hours > 0) return `${hours}時間${minutes}分`
+    return `${minutes}分`
+  })
+
+  return {
+    playlist,
+    songs: readonly(songs),
+    status: readonly(status),
+    totalDuration,
+    fetchSongs,
+  }
+}

--- a/app/pages/playlists/[id].vue
+++ b/app/pages/playlists/[id].vue
@@ -1,10 +1,249 @@
 <template>
   <div>
-    <h1 class="mb-6 text-xl font-bold">プレイリスト詳細</h1>
-    <p class="text-gray-500">プレイリスト機能は準備中です</p>
+    <!-- Back link -->
+    <NuxtLink
+      to="/playlists"
+      class="mb-4 inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white"
+    >
+      <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+      プレイリスト一覧
+    </NuxtLink>
+
+    <!-- Not found -->
+    <div v-if="!playlist" class="px-4 py-16 text-center">
+      <p class="text-sm text-gray-400">プレイリストが見つかりません</p>
+      <NuxtLink to="/playlists" class="mt-2 inline-block text-sm text-emerald-400 hover:underline">
+        一覧に戻る
+      </NuxtLink>
+    </div>
+
+    <template v-else>
+      <!-- Header -->
+      <div class="mb-6">
+        <!-- Title / Edit -->
+        <div v-if="isEditing" class="mb-3 flex items-center gap-3">
+          <input
+            ref="editInput"
+            v-model="editName"
+            class="flex-1 border border-border-default bg-surface-overlay px-3 py-2 text-sm text-gray-50 focus:border-accent focus:outline-none"
+            maxlength="100"
+            @keydown.enter="saveEdit"
+            @keydown.escape="cancelEdit"
+          />
+          <button
+            class="bg-emerald-500 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="!editName.trim()"
+            @click="saveEdit"
+          >
+            保存
+          </button>
+          <button class="text-sm text-gray-400 hover:text-white" @click="cancelEdit">
+            キャンセル
+          </button>
+        </div>
+        <div v-else class="flex items-start justify-between gap-4">
+          <div>
+            <h1 class="text-xl font-bold">{{ playlist.name }}</h1>
+            <p v-if="playlist.description" class="mt-1 text-sm text-gray-400">
+              {{ playlist.description }}
+            </p>
+          </div>
+          <div class="flex shrink-0 gap-2">
+            <button class="px-2 py-1 text-xs text-gray-400 hover:text-white" @click="startEdit">
+              編集
+            </button>
+            <button
+              class="px-2 py-1 text-xs text-gray-400 hover:text-red-400"
+              @click="handleDelete"
+            >
+              削除
+            </button>
+          </div>
+        </div>
+
+        <!-- Meta + actions -->
+        <div class="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <span v-if="songs.length > 0" class="text-xs text-gray-400">
+            {{ songs.length }}曲 &middot; {{ totalDuration }}
+          </span>
+          <div v-if="songs.length > 0" class="flex gap-2">
+            <button
+              class="bg-emerald-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-400"
+              @click="handlePlayAll"
+            >
+              すべて再生
+            </button>
+            <button
+              class="border border-border-default px-4 py-2 text-sm text-gray-400 transition-colors hover:text-white"
+              @click="handleAddAllToQueue"
+            >
+              キューに追加
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="status === 'pending'" class="space-y-2">
+        <div v-for="n in 5" :key="n" class="h-14 animate-pulse bg-surface-raised" />
+      </div>
+
+      <!-- Error -->
+      <div v-else-if="status === 'error'" class="px-4 py-8 text-center text-sm text-gray-400">
+        楽曲情報の取得に失敗しました
+      </div>
+
+      <!-- Song list with drag support -->
+      <ClientOnly v-else-if="songs.length > 0">
+        <VueDraggableNext
+          v-model="draggableSongs"
+          handle=".drag-handle"
+          animation="150"
+          @end="handleDragEnd"
+        >
+          <div
+            v-for="(song, index) in draggableSongs"
+            :key="`${song.id}-${index}`"
+            class="flex items-center"
+          >
+            <!-- Drag handle -->
+            <div
+              class="drag-handle flex shrink-0 cursor-grab items-center justify-center px-1 text-gray-600 hover:text-gray-400 active:cursor-grabbing"
+              title="ドラッグで並び替え"
+            >
+              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 8h16M4 16h16"
+                />
+              </svg>
+            </div>
+
+            <!-- Song row (reusing SongListItem) -->
+            <div class="min-w-0 flex-1">
+              <SongListItem :song="song" :index="index">
+                <template #extra-actions>
+                  <button
+                    class="p-1 text-gray-400 hover:text-red-400"
+                    title="プレイリストから削除"
+                    @click.stop="handleRemoveSong(index)"
+                  >
+                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                      />
+                    </svg>
+                  </button>
+                </template>
+              </SongListItem>
+            </div>
+          </div>
+        </VueDraggableNext>
+      </ClientOnly>
+
+      <!-- Empty playlist -->
+      <div v-else-if="status === 'ready'" class="px-4 py-8 text-center text-sm text-gray-400">
+        このプレイリストにはまだ曲がありません
+      </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-useHead({ title: 'プレイリスト | inuinouta' })
+import { VueDraggableNext } from 'vue-draggable-next'
+import type { Song } from '~/types'
+
+const route = useRoute()
+const playlistId = route.params.id as string
+
+const playlistsStore = usePlaylistsStore()
+const queueActions = useQueueActions()
+
+onMounted(() => {
+  playlistsStore.loadFromStorage()
+})
+
+const { playlist, songs, status, totalDuration, fetchSongs } = usePlaylistDetail(playlistId)
+
+useHead({ title: computed(() => `${playlist.value?.name ?? 'プレイリスト'} | inuinouta`) })
+
+// Fetch songs once store is loaded
+watch(
+  () => playlistsStore.loaded,
+  (isLoaded) => {
+    if (isLoaded) fetchSongs()
+  },
+  { immediate: true },
+)
+
+// Draggable songs mirror
+const draggableSongs = ref<Song[]>([])
+
+watch(
+  songs,
+  (newSongs) => {
+    draggableSongs.value = [...newSongs]
+  },
+  { immediate: true },
+)
+
+function handleDragEnd(event: { oldIndex: number; newIndex: number }) {
+  // vue-draggable-next has already updated draggableSongs via v-model; just persist to store
+  playlistsStore.reorderItems(playlistId, event.oldIndex, event.newIndex)
+}
+
+function handlePlayAll() {
+  if (songs.value.length === 0) return
+  queueActions.playAll([...songs.value])
+}
+
+function handleAddAllToQueue() {
+  songs.value.forEach((song) => queueActions.addToQueue(song))
+}
+
+function handleRemoveSong(index: number) {
+  const pl = playlist.value
+  if (!pl) return
+  const item = pl.items[index]
+  if (!item) return
+  playlistsStore.removeSong(playlistId, item.id)
+  draggableSongs.value.splice(index, 1)
+}
+
+// Edit
+const isEditing = ref(false)
+const editName = ref('')
+const editInput = ref<HTMLInputElement | null>(null)
+
+function startEdit() {
+  if (!playlist.value) return
+  editName.value = playlist.value.name
+  isEditing.value = true
+  nextTick(() => editInput.value?.focus())
+}
+
+function saveEdit() {
+  const name = editName.value.trim()
+  if (!name) return
+  playlistsStore.updatePlaylist(playlistId, { name })
+  isEditing.value = false
+}
+
+function cancelEdit() {
+  isEditing.value = false
+}
+
+// Delete
+function handleDelete() {
+  if (!confirm(`「${playlist.value?.name}」を削除しますか？`)) return
+  playlistsStore.deletePlaylist(playlistId)
+  navigateTo('/playlists')
+}
 </script>

--- a/app/pages/playlists/index.vue
+++ b/app/pages/playlists/index.vue
@@ -1,13 +1,158 @@
 <template>
   <div>
-    <h1 class="mb-6 text-xl font-bold">プレイリスト</h1>
-    <p class="text-gray-500">プレイリスト機能は準備中です</p>
-    <p class="mt-3 text-sm text-gray-600">
-      現在は再生キューで曲の並び順を管理できます。楽曲一覧や動画詳細から「キューに追加」してお試しください。
-    </p>
+    <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <h1 class="text-xl font-bold">プレイリスト</h1>
+      <button
+        class="self-start bg-emerald-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-400"
+        @click="isCreating = true"
+      >
+        新規作成
+      </button>
+    </div>
+
+    <!-- Inline create form -->
+    <div
+      v-if="isCreating"
+      class="mb-4 flex items-center gap-3 border-b border-border-default px-3 py-3"
+    >
+      <input
+        ref="nameInput"
+        v-model="newName"
+        class="flex-1 border border-border-default bg-surface-overlay px-3 py-2 text-sm text-gray-50 focus:border-accent focus:outline-none"
+        placeholder="プレイリスト名"
+        maxlength="100"
+        @keydown.enter="handleCreate"
+        @keydown.escape="cancelCreate"
+      />
+      <button
+        class="bg-emerald-500 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+        :disabled="!newName.trim()"
+        @click="handleCreate"
+      >
+        作成
+      </button>
+      <button class="text-sm text-gray-400 hover:text-white" @click="cancelCreate">
+        キャンセル
+      </button>
+    </div>
+
+    <!-- Playlist list -->
+    <div v-if="playlistsStore.playlists.length > 0">
+      <NuxtLink
+        v-for="pl in playlistsStore.playlists"
+        :key="pl.id"
+        :to="`/playlists/${pl.id}`"
+        class="group flex items-center gap-4 border-b border-border-default px-3 py-3 transition-colors hover:bg-surface-overlay"
+      >
+        <!-- List icon -->
+        <svg
+          class="h-5 w-5 shrink-0 text-gray-500"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 6h16M4 10h16M4 14h10"
+          />
+        </svg>
+
+        <!-- Info -->
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-sm font-medium text-gray-50">{{ pl.name }}</p>
+          <p v-if="pl.description" class="truncate text-xs text-gray-500">{{ pl.description }}</p>
+        </div>
+
+        <!-- Meta -->
+        <span class="shrink-0 text-xs text-gray-400">{{ pl.items.length }}曲</span>
+
+        <!-- Chevron -->
+        <svg
+          class="h-4 w-4 shrink-0 text-gray-600 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+      </NuxtLink>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!isCreating" class="px-4 py-16 text-center">
+      <svg
+        class="mx-auto mb-4 h-16 w-16 text-gray-600"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+          d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"
+        />
+      </svg>
+      <p class="text-sm text-gray-400">プレイリストがありません</p>
+      <p class="mt-1 text-xs text-gray-500">再生キューから保存してみましょう</p>
+    </div>
+
+    <!-- LocalStorage notice -->
+    <div
+      v-if="playlistsStore.playlists.length > 0"
+      class="mt-6 flex items-start gap-2 border border-border-default px-4 py-3 text-sm text-gray-400"
+    >
+      <svg
+        class="mt-0.5 h-4 w-4 shrink-0 text-gray-500"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+      <p>
+        プレイリストはこのブラウザに保存されます。別のデバイスやブラウザからはアクセスできません。
+      </p>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 useHead({ title: 'プレイリスト | inuinouta' })
+
+const playlistsStore = usePlaylistsStore()
+
+onMounted(() => {
+  playlistsStore.loadFromStorage()
+})
+
+const isCreating = ref(false)
+const newName = ref('')
+const nameInput = ref<HTMLInputElement | null>(null)
+
+watch(isCreating, (val) => {
+  if (val) {
+    nextTick(() => nameInput.value?.focus())
+  }
+})
+
+function handleCreate() {
+  const name = newName.value.trim()
+  if (!name) return
+  playlistsStore.createPlaylist(name)
+  newName.value = ''
+  isCreating.value = false
+}
+
+function cancelCreate() {
+  newName.value = ''
+  isCreating.value = false
+}
 </script>

--- a/app/stores/playlists.ts
+++ b/app/stores/playlists.ts
@@ -1,0 +1,135 @@
+import type { LocalPlaylist, LocalPlaylistItem } from '~/types'
+
+const STORAGE_KEY = 'local_playlists'
+
+export const usePlaylistsStore = defineStore('playlists', () => {
+  const playlists = ref<LocalPlaylist[]>([])
+  const loaded = ref(false)
+
+  function loadFromStorage() {
+    if (loaded.value) return
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (raw) {
+        playlists.value = JSON.parse(raw) as LocalPlaylist[]
+      }
+    } catch {
+      playlists.value = []
+    }
+    loaded.value = true
+  }
+
+  function saveToStorage() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(playlists.value))
+    } catch {
+      // Ignore storage errors (quota exceeded, private mode)
+    }
+  }
+
+  function getById(id: string): LocalPlaylist | undefined {
+    return playlists.value.find((p) => p.id === id)
+  }
+
+  function createPlaylist(name: string, description = '', songIds: number[] = []): LocalPlaylist {
+    const now = new Date().toISOString()
+    const items: LocalPlaylistItem[] = songIds.map((songId, i) => ({
+      id: crypto.randomUUID(),
+      song_id: songId,
+      order: i,
+    }))
+    const playlist: LocalPlaylist = {
+      id: crypto.randomUUID(),
+      name,
+      description,
+      items,
+      created_at: now,
+      updated_at: now,
+    }
+    playlists.value.push(playlist)
+    saveToStorage()
+    return playlist
+  }
+
+  function updatePlaylist(id: string, data: { name?: string; description?: string }) {
+    const playlist = getById(id)
+    if (!playlist) return
+    if (data.name !== undefined) playlist.name = data.name
+    if (data.description !== undefined) playlist.description = data.description
+    playlist.updated_at = new Date().toISOString()
+    saveToStorage()
+  }
+
+  function deletePlaylist(id: string) {
+    const index = playlists.value.findIndex((p) => p.id === id)
+    if (index === -1) return
+    playlists.value.splice(index, 1)
+    saveToStorage()
+  }
+
+  function addSong(playlistId: string, songId: number) {
+    const playlist = getById(playlistId)
+    if (!playlist) return
+    playlist.items.push({
+      id: crypto.randomUUID(),
+      song_id: songId,
+      order: playlist.items.length,
+    })
+    playlist.updated_at = new Date().toISOString()
+    saveToStorage()
+  }
+
+  function addSongs(playlistId: string, songIds: number[]) {
+    const playlist = getById(playlistId)
+    if (!playlist || songIds.length === 0) return
+    songIds.forEach((songId) => {
+      playlist.items.push({
+        id: crypto.randomUUID(),
+        song_id: songId,
+        order: playlist.items.length,
+      })
+    })
+    playlist.updated_at = new Date().toISOString()
+    saveToStorage()
+  }
+
+  function removeSong(playlistId: string, itemId: string) {
+    const playlist = getById(playlistId)
+    if (!playlist) return
+    const index = playlist.items.findIndex((item) => item.id === itemId)
+    if (index === -1) return
+    playlist.items.splice(index, 1)
+    playlist.items.forEach((item, i) => {
+      item.order = i
+    })
+    playlist.updated_at = new Date().toISOString()
+    saveToStorage()
+  }
+
+  function reorderItems(playlistId: string, from: number, to: number) {
+    const playlist = getById(playlistId)
+    if (!playlist || from === to) return
+    const [moved] = playlist.items.splice(from, 1)
+    if (!moved) return
+    playlist.items.splice(to, 0, moved)
+    playlist.items.forEach((item, i) => {
+      item.order = i
+    })
+    playlist.updated_at = new Date().toISOString()
+    saveToStorage()
+  }
+
+  return {
+    playlists: readonly(playlists),
+    loaded: readonly(loaded),
+    loadFromStorage,
+    getById,
+    createPlaylist,
+    updatePlaylist,
+    deletePlaylist,
+    addSong,
+    addSongs,
+    removeSong,
+    reorderItems,
+  }
+})

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -35,7 +35,7 @@ export interface Song extends SongBasic {
   video: VideoBasic
 }
 
-// --- Playlist ---
+// --- Playlist (API) ---
 
 export interface PlaylistItem {
   id: number
@@ -49,6 +49,23 @@ export interface Playlist {
   description: string
   created_at: string
   items: PlaylistItem[]
+}
+
+// --- Playlist (Local-first / localStorage) ---
+
+export interface LocalPlaylistItem {
+  id: string // UUID
+  song_id: number
+  order: number
+}
+
+export interface LocalPlaylist {
+  id: string // UUID
+  name: string
+  description: string
+  items: LocalPlaylistItem[]
+  created_at: string // ISO 8601
+  updated_at: string // ISO 8601
 }
 
 // --- API Response Wrappers (dynamic-rest format) ---


### PR DESCRIPTION
Closes #23

## 概要

localStorage ベースの Local-first プレイリスト機能を実装しました。サーバーへの保存なしに、ブラウザ内でプレイリストを作成・管理できます。

## 実装内容

### 型定義
- `LocalPlaylist` / `LocalPlaylistItem` 型を追加（UUID ベース。API の `Playlist` 型 (id: number) と明示的に分離）

### 新規ファイル

| ファイル | 説明 |
|---|---|
| `app/stores/playlists.ts` | LocalPlaylist の CRUD + localStorage 永続化（作成・更新・削除・曲追加/バッチ追加・曲削除・並び替え） |
| `app/composables/usePlaylistDetail.ts` | song_id → Song バッチ取得（`/api/songs/?filter{id.in}=...`） |
| `app/components/AddToPlaylistDropdown.vue` | 曲単体からプレイリストへの追加ドロップダウン（既存選択 / インライン新規作成） |

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/pages/playlists/index.vue` | 一覧表示・インライン作成フォーム・空状態 |
| `app/pages/playlists/[id].vue` | 詳細・ドラッグ並び替え・タイトル編集・削除・曲削除 |
| `app/components/SongListItem.vue` | `AddToPlaylistDropdown` を組み込み（全楽曲リストで利用可能に） |
| `app/components/QueueDrawer.vue` | 「保存」を「新規作成 / 既存に追加」タブ切り替えに拡張 |

## プレイリスト構築フロー

```
楽曲リストから直接追加: SongListItem のブックマークアイコン → 既存選択 or 新規作成
キューをまとめて保存: QueueDrawer の「保存」→「新規作成」or「既存に追加（append）」
```

## バグ修正

- `playlists/[id].vue`: 曲削除・並び替え後の不要な `fetchSongs()` 呼び出し（API リクエスト）を除去し、インメモリ更新のみに変更
- `AddToPlaylistDropdown.vue`: ドロップダウン open 中にマウスが曲行の外に出ると opacity-0 で消える問題を `:has(.dropdown-open)` で修正