### PR TITLE
feat: 楽曲・動画一覧を全ページ共通で事前ロードする

### DIFF
--- a/app/composables/useSongs.ts
+++ b/app/composables/useSongs.ts
@@ -52,10 +52,13 @@ export function useSongs(options?: { perPage?: number }) {
     { immediate: true },
   )
 
-  // Fetch on first use (SSR + client)
+  // SSR prefetch: when directly loading a page that uses this composable
   onServerPrefetch(() => callOnce('library-songs', () => library.fetchSongs()))
 
-  if (import.meta.client) {
+  // Client-side preload is handled by default.vue layout (runs on every page).
+  // This fallback ensures data is available if the composable is used
+  // outside a context where the layout has already triggered the preload.
+  if (import.meta.client && library.songsStatus === 'idle') {
     void callOnce('library-songs', () => library.fetchSongs())
   }
 

--- a/app/composables/useVideos.ts
+++ b/app/composables/useVideos.ts
@@ -30,10 +30,13 @@ export function useVideos(options?: { perPage?: number }) {
     page.value = 1
   })
 
-  // Fetch on first use (SSR + client)
+  // SSR prefetch: when directly loading a page that uses this composable
   onServerPrefetch(() => callOnce('library-videos', () => library.fetchVideos()))
 
-  if (import.meta.client) {
+  // Client-side preload is handled by default.vue layout (runs on every page).
+  // This fallback ensures data is available if the composable is used
+  // outside a context where the layout has already triggered the preload.
+  if (import.meta.client && library.videosStatus === 'idle') {
     void callOnce('library-videos', () => library.fetchVideos())
   }
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -55,4 +55,12 @@
 
 <script setup lang="ts">
 const sideNavOpen = ref(false)
+
+// Background preload for songs/videos on every page so data is warm
+// before the user navigates to /songs, /videos or /search
+const library = useLibraryStore()
+if (import.meta.client) {
+  void callOnce('library-songs', () => library.fetchSongs())
+  void callOnce('library-videos', () => library.fetchVideos())
+}
 </script>


### PR DESCRIPTION
## 概要

どのページからでも `/songs` `/videos` `/search` へ素早く遷移できるよう、songs / videos 全件データを全ページ共通で事前ロードする。

Closes #36

## 変更内容

### `app/layouts/default.vue`

- クライアント側で `callOnce('library-songs', ...)` と `callOnce('library-videos', ...)` を実行するコードを追加
- アプリシェル表示直後から background preload が始まり、Pinia store を温める

### `app/composables/useSongs.ts` / `app/composables/useVideos.ts`

- クライアント側の `callOnce` ブロックを削除（layout に責務を移管）
- SSR 用 `onServerPrefetch` は維持（/songs /videos への直接アクセス時の SSR 互換）
- フォールバック: layout 外で使われる場合のために `songsStatus / videosStatus === 'idle'` 時のみ発火するガードを残す

## 動作への影響

| シナリオ | Before | After |
|---|---|---|
| トップページ → /songs 遷移 | /songs 到達時に API 取得開始 | トップ表示時点で preload 開始済み |
| /songs 直接アクセス（SSR） | onServerPrefetch でフェッチ | 変わらず（onServerPrefetch 残存） |
| 二重取得 | callOnce キーで防止 | 変わらず（同じキー） |

## テスト観点

- [ ] トップページを開いた直後にネットワークタブで songs / videos のリクエストが走ることを確認
- [ ] `/songs` `/videos` への遷移後に追加 API コールが発生しないことを確認
- [ ] `/songs` への直接アクセス（SSR）で楽曲一覧が正常表示されることを確認
- [ ] 検索・フィルタ・ページネーションの動作が維持されることを確認