### PR TITLE
[videos] 動画一覧にフィルタバーを追加する（テキスト検索接続）

### DIFF
--- a/app/composables/useVideos.ts
+++ b/app/composables/useVideos.ts
@@ -2,6 +2,7 @@ import type { VideoList } from '~/types'
 
 export function useVideos(options?: { perPage?: number }) {
   const library = useLibraryStore()
+  const route = useRoute()
   const page = ref(1)
   const perPage = options?.perPage ?? 30
   const search = ref('')
@@ -29,6 +30,15 @@ export function useVideos(options?: { perPage?: number }) {
   watch(search, () => {
     page.value = 1
   })
+
+  // Sync search from URL query ?q=
+  watch(
+    () => route.query.q,
+    (q) => {
+      search.value = typeof q === 'string' ? q : ''
+    },
+    { immediate: true },
+  )
 
   // SSR prefetch: when directly loading a page that uses this composable
   onServerPrefetch(() => callOnce('library-videos', () => library.fetchVideos()))

--- a/app/pages/videos/index.vue
+++ b/app/pages/videos/index.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <h1 class="mb-6 text-xl font-bold">動画一覧</h1>
+    <h1 class="mb-6 text-xl font-bold text-gray-50">動画一覧</h1>
+
+    <!-- Result count -->
+    <p class="mb-4 text-sm text-gray-400">{{ totalItems }} 件見つかりました</p>
 
     <!-- Loading -->
     <div v-if="status === 'pending'" class="grid grid-cols-2 gap-3 lg:grid-cols-3">
@@ -13,10 +16,17 @@
       </div>
     </div>
 
-    <!-- Video grid -->
-    <div v-else class="grid grid-cols-2 gap-3 lg:grid-cols-3">
-      <VideoCard v-for="video in videos" :key="video.id" :video="video" />
-    </div>
+    <template v-else>
+      <!-- Empty state -->
+      <div v-if="videos.length === 0" class="py-12 text-center text-gray-400">
+        動画が見つかりませんでした
+      </div>
+
+      <!-- Video grid -->
+      <div v-else class="grid grid-cols-2 gap-3 lg:grid-cols-3">
+        <VideoCard v-for="video in videos" :key="video.id" :video="video" />
+      </div>
+    </template>
 
     <!-- Pagination -->
     <div class="mt-6">


### PR DESCRIPTION
## 概要

#31 の対応。グローバル SearchBar（`?q=` クエリ）を `useVideos` に接続し、動画一覧でもテキスト検索が動くようにする。

## 変更内容

### `app/composables/useVideos.ts`

- `const route = useRoute()` を追加
- `route.query.q` を watch し `search` ref に即時同期（`useSongs` の #28 対応と対称）

### `app/pages/videos/index.vue`

- 件数テキスト「〇 件見つかりました」を追加
- ローディング後の分岐を `<template v-else>` でラップし、0 件時の空状態メッセージを追加
- `h1` に `text-gray-50` を明示（`songs/index.vue` と統一）

## 受け入れ条件

- [x] グローバル SearchBar に入力すると動画一覧がタイトルで絞り込まれる
- [x] 結果件数「〇 件見つかりました」が表示される
- [x] 0 件時に「動画が見つかりませんでした」が表示される
- [x] フィルタ変更でページが 1 に戻る

Closes #31