### PR TITLE
[songs] アーティスト絞り込みモーダルを追加する（タグクラウド・URL同期）

### DIFF
--- a/app/components/ArtistCloudModal.vue
+++ b/app/components/ArtistCloudModal.vue
@@ -1,0 +1,111 @@
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-150"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="isOpen"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80"
+        @click.self="$emit('close')"
+      >
+        <div class="w-full max-w-lg bg-surface-overlay flex flex-col max-h-[70vh]">
+          <!-- Modal header -->
+          <div class="flex items-center justify-between border-b border-border-default px-4 py-3">
+            <h2 class="text-sm font-medium text-gray-50">アーティストを選択</h2>
+            <button
+              class="text-gray-400 hover:text-gray-50 transition-colors"
+              aria-label="閉じる"
+              @click="$emit('close')"
+            >
+              ✕
+            </button>
+          </div>
+
+          <!-- Search input -->
+          <div class="border-b border-border-default px-4 py-2">
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="アーティスト名で絞り込む"
+              class="w-full bg-transparent text-sm text-gray-50 placeholder-gray-500 outline-none"
+            />
+          </div>
+
+          <!-- Artist list -->
+          <div class="overflow-y-auto px-4 py-3">
+            <div class="flex flex-wrap gap-2">
+              <!-- All artists (clear) button -->
+              <button
+                class="border px-3 py-1.5 text-sm transition-colors"
+                :class="
+                  selectedArtist === ''
+                    ? 'border-emerald-500 bg-emerald-500/10 text-emerald-400'
+                    : 'border-border-default text-gray-400 hover:text-gray-50'
+                "
+                @click="$emit('select', '')"
+              >
+                全アーティスト
+              </button>
+
+              <!-- Artist buttons -->
+              <button
+                v-for="artist in filteredArtists"
+                :key="artist.name"
+                class="border px-3 py-1.5 text-sm transition-colors"
+                :class="
+                  selectedArtist === artist.name
+                    ? 'border-emerald-500 bg-emerald-500/10 text-emerald-400'
+                    : 'border-border-default text-gray-400 hover:text-gray-50'
+                "
+                @click="$emit('select', artist.name)"
+              >
+                {{ artist.name }}<span class="ml-1.5 text-xs opacity-60">{{ artist.count }}</span>
+              </button>
+            </div>
+
+            <!-- Empty state -->
+            <p v-if="filteredArtists.length === 0" class="py-6 text-center text-sm text-gray-400">
+              アーティストが見つかりませんでした
+            </p>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import type { ArtistWithCount } from '~/composables/useSongs'
+
+const props = defineProps<{
+  isOpen: boolean
+  selectedArtist: string
+  artists: ArtistWithCount[]
+}>()
+
+defineEmits<{
+  close: []
+  select: [artistName: string]
+}>()
+
+const searchQuery = ref('')
+
+const filteredArtists = computed(() => {
+  const q = searchQuery.value.toLowerCase()
+  if (!q) return props.artists
+  return props.artists.filter((a) => a.name.toLowerCase().includes(q))
+})
+
+// Reset search when modal opens
+watch(
+  () => props.isOpen,
+  (open) => {
+    if (open) searchQuery.value = ''
+  },
+)
+</script>

--- a/app/composables/useSongs.ts
+++ b/app/composables/useSongs.ts
@@ -3,14 +3,21 @@ import type { Song } from '~/types'
 export type SongTypeFilter = '' | 'original' | 'cover'
 export type VideoTypeFilter = '' | 'music_video' | 'stream'
 
+export interface ArtistWithCount {
+  name: string
+  count: number
+}
+
 export function useSongs(options?: { perPage?: number }) {
   const library = useLibraryStore()
   const route = useRoute()
+  const router = useRouter()
   const page = ref(1)
   const perPage = options?.perPage ?? 30
   const search = ref('')
   const songType = ref<SongTypeFilter>('')
   const videoType = ref<VideoTypeFilter>('')
+  const selectedArtist = ref('')
 
   const status = computed(() => (library.songsStatus === 'idle' ? 'pending' : library.songsStatus))
   const error = computed(() => library.songsError)
@@ -20,6 +27,7 @@ export function useSongs(options?: { perPage?: number }) {
     const q = search.value.toLowerCase()
     const st = songType.value
     const vt = videoType.value
+    const artist = selectedArtist.value
     return all.filter((s) => {
       const matchText =
         !q ||
@@ -27,8 +35,20 @@ export function useSongs(options?: { perPage?: number }) {
         (s.artist != null && s.artist.toLowerCase().includes(q))
       const matchSongType = st === '' || (st === 'original' ? s.is_original : !s.is_original)
       const matchVideoType = vt === '' || (vt === 'stream' ? s.video.is_stream : !s.video.is_stream)
-      return matchText && matchSongType && matchVideoType
+      const matchArtist = !artist || s.artist === artist
+      return matchText && matchSongType && matchVideoType && matchArtist
     })
+  })
+
+  // Artist list with counts, derived from all songs (not filtered), sorted by count desc
+  const artistsWithCount = computed<ArtistWithCount[]>(() => {
+    const counts: Record<string, number> = {}
+    library.allSongs.forEach((s) => {
+      if (s.artist) counts[s.artist] = (counts[s.artist] ?? 0) + 1
+    })
+    return Object.entries(counts)
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count)
   })
 
   const totalItems = computed(() => filtered.value.length)
@@ -39,7 +59,7 @@ export function useSongs(options?: { perPage?: number }) {
   })
 
   // Reset page when any filter changes
-  watch([search, songType, videoType], () => {
+  watch([search, songType, videoType, selectedArtist], () => {
     page.value = 1
   })
 
@@ -51,6 +71,20 @@ export function useSongs(options?: { perPage?: number }) {
     },
     { immediate: true },
   )
+
+  // Sync selectedArtist from URL query ?artist=
+  watch(
+    () => route.query.artist,
+    (a) => {
+      selectedArtist.value = typeof a === 'string' ? a : ''
+    },
+    { immediate: true },
+  )
+
+  function selectArtist(name: string) {
+    selectedArtist.value = name
+    router.replace({ query: { ...route.query, artist: name || undefined } })
+  }
 
   // SSR prefetch: when directly loading a page that uses this composable
   onServerPrefetch(() => callOnce('library-songs', () => library.fetchSongs()))
@@ -66,5 +100,19 @@ export function useSongs(options?: { perPage?: number }) {
     return library.fetchSongs(true)
   }
 
-  return { songs, totalItems, page, perPage, search, songType, videoType, status, error, refresh }
+  return {
+    songs,
+    totalItems,
+    page,
+    perPage,
+    search,
+    songType,
+    videoType,
+    selectedArtist,
+    artistsWithCount,
+    selectArtist,
+    status,
+    error,
+    refresh,
+  }
 }

--- a/app/pages/songs/index.vue
+++ b/app/pages/songs/index.vue
@@ -19,7 +19,7 @@
         <button
           v-for="t in songTypeOptions"
           :key="t.value"
-          class="relative ml-[-1px] border border-border-default px-3 py-1.5 text-sm transition-colors first:ml-0"
+          class="relative -ml-px border border-border-default px-3 py-1.5 text-sm transition-colors first:ml-0"
           :class="
             songType === t.value
               ? 'z-10 border-emerald-500 bg-emerald-500/10 text-emerald-400'
@@ -36,7 +36,7 @@
         <button
           v-for="t in videoTypeOptions"
           :key="t.value"
-          class="relative ml-[-1px] border border-border-default px-3 py-1.5 text-sm transition-colors first:ml-0"
+          class="relative -ml-px border border-border-default px-3 py-1.5 text-sm transition-colors first:ml-0"
           :class="
             videoType === t.value
               ? 'z-10 border-emerald-500 bg-emerald-500/10 text-emerald-400'
@@ -47,7 +47,29 @@
           {{ t.label }}
         </button>
       </div>
+
+      <!-- Artist filter button -->
+      <button
+        class="border px-3 py-1.5 text-sm transition-colors"
+        :class="
+          selectedArtist
+            ? 'border-emerald-500 bg-emerald-500/10 text-emerald-400'
+            : 'border-border-default text-gray-400 hover:text-gray-50'
+        "
+        @click="artistModalOpen = true"
+      >
+        {{ selectedArtist || '全アーティスト' }} ▼
+      </button>
     </div>
+
+    <!-- Artist cloud modal -->
+    <ArtistCloudModal
+      :is-open="artistModalOpen"
+      :selected-artist="selectedArtist"
+      :artists="artistsWithCount"
+      @close="artistModalOpen = false"
+      @select="onSelectArtist"
+    />
 
     <!-- Result count -->
     <p class="mb-4 text-sm text-gray-400">{{ totalItems }} 曲見つかりました</p>
@@ -92,8 +114,26 @@ import type { SongTypeFilter, VideoTypeFilter } from '~/composables/useSongs'
 
 useHead({ title: '楽曲一覧 | inuinouta' })
 
-const { songs, totalItems, page, perPage, songType, videoType, status } = useSongs({ perPage: 50 })
+const {
+  songs,
+  totalItems,
+  page,
+  perPage,
+  songType,
+  videoType,
+  selectedArtist,
+  artistsWithCount,
+  selectArtist,
+  status,
+} = useSongs({ perPage: 50 })
 const queueActions = useQueueActions()
+
+const artistModalOpen = ref(false)
+
+function onSelectArtist(name: string) {
+  selectArtist(name)
+  artistModalOpen.value = false
+}
 
 const songTypeOptions: { value: SongTypeFilter; label: string }[] = [
   { value: '', label: 'すべて' },


### PR DESCRIPTION
## 概要

楽曲一覧ページにアーティスト絞り込みをタグクラウドモーダルで追加する。  
選択したアーティストを `?artist=` URL クエリに同期し、ブックマーク・共有可能にする。

Closes #29

## 変更内容

### `app/components/ArtistCloudModal.vue`（新規）

- `Teleport to="body"` + `Transition` でフェードイン/アウトするモーダル
- 背景オーバーレイ `bg-black/80`・パネル `bg-surface-overlay`・角丸なし
- モーダル内テキスト絞り込み input（開くたびリセット）
- 「全アーティスト」ボタンを最上部に配置（選択解除）
- アーティストボタン: 楽曲数順・件数薄表示・ボーダー付き
- 選択中スタイル: `border-emerald-500 bg-emerald-500/10 text-emerald-400`
- `flex flex-col max-h-[70vh]` でヘッダー固定・リストのみスクロール

### `app/composables/useSongs.ts`

- `selectedArtist` ref を追加
- `route.query.artist` を watch して URL→状態を同期（immediate: true）
- `selectArtist(name)` 関数で状態→URL を同期（`router.replace`）
- `filtered` computed に `matchArtist` 条件を追加（他フィルタとの複合対応）
- `artistsWithCount` computed を追加（全楽曲ベース・null 除外・件数降順）
- `ArtistWithCount` 型をエクスポート

### `app/pages/songs/index.vue`

- フィルタバーに「全アーティスト ▼」ボタンを追加
  - 選択中: `border-emerald-500 bg-emerald-500/10 text-emerald-400`（既存トグルと統一）
- `ArtistCloudModal` を配置し `artistModalOpen` ref で開閉を管理
- 既存の `ml-[-1px]` を `-ml-px` に修正（リントエラー解消）

## 受け入れ条件

- [x] 「全アーティスト ▼」ボタンをクリックするとモーダルが開く
- [x] モーダルにアーティスト一覧が件数付きで楽曲数順に表示される
- [x] モーダル内の検索でアーティストを絞り込める
- [x] アーティストを選択すると楽曲一覧が絞り込まれ、ボタンに選択中アーティスト名が表示される
- [x] 「全アーティスト」を選択すると絞り込みが解除される
- [x] 選択状態が `?artist=` URL クエリに同期される
- [x] URL に `?artist=アーティスト名` を付けて直接アクセスすると絞り込み済みで表示される
- [x] モバイル幅（390px）でモーダルが崩れない（`p-4` ラッパー + `w-full max-w-lg`）