### PR TITLE
fix(playback): 曲終了後の次曲遷移で1曲スキップされる不具合を修正 #52

### DIFF
--- a/app/composables/useYouTubePlayer.ts
+++ b/app/composables/useYouTubePlayer.ts
@@ -19,6 +19,14 @@ let pendingRequest: { videoId: string; startSeconds: number; endSeconds?: number
 
 let intervalId: ReturnType<typeof setInterval> | null = null
 
+/**
+ * True while a song-end transition is in progress.
+ * Prevents duplicate nextSong() calls when the ENDED state event fires
+ * spuriously during loadVideoById (e.g. immediately after loading a new video).
+ * Reset to false when the next video reaches PLAYING state.
+ */
+let isTransitioning = false
+
 // ---------------------------------------------------------------------------
 
 export function useYouTubePlayer() {
@@ -88,6 +96,7 @@ export function useYouTubePlayer() {
   function handleStateChange(event: YT.OnStateChangeEvent) {
     const state = event.data
     if (state === 1 /* PLAYING */) {
+      isTransitioning = false
       player.setPlaying(true)
       startTimeTracking()
     } else if (state === 2 /* PAUSED */) {
@@ -121,6 +130,9 @@ export function useYouTubePlayer() {
   }
 
   function onSongEnd() {
+    if (isTransitioning) return
+    isTransitioning = true
+    stopTimeTracking()
     const { nextSong } = usePlayback()
     nextSong()
   }


### PR DESCRIPTION
## 概要

Closes #52

曲終了後の自動遷移で `nextSong()` が二重実行され、1曲スキップされる不具合を修正します。

## 根本原因

`loadVideoById()` を呼び出した直後、YouTube IFrame API が新しい動画のロード中に ENDED 状態イベントを発火することがある。このとき `player.currentSong` はすでに次曲に更新されているため、`onSongEnd()` が2回目として実行され、さらに1曲先へ進む。

```
[time tracking] end_at 到達 → onSongEnd() → nextSong() → loadVideoById(次曲)
[YouTube]       loadVideoById 直後に ENDED イベント発火
→ onSongEnd() が再度呼ばれ nextSong() がもう1回実行される
```

## 修正内容

`useYouTubePlayer.ts` のみ変更。

- モジュールレベルに `isTransitioning` フラグを追加
- `onSongEnd()` の先頭でフラグをチェックし、遷移中なら即リターン
- `onSongEnd()` 内で `stopTimeTracking()` を先に呼び、time tracking 経由の2回目も確実にブロック
- 次曲の PLAYING イベントで `isTransitioning = false` にリセット

## 動作確認

- 複数曲キュー再生で、曲終了後に次の1曲だけへ順番に進むことを確認
- `end_at` 指定あり（区間再生）・なし（自然終了）の両方で再現なし
