### PR TITLE
fix(playback): キュー末尾到達後も PlayerBar を維持し、再生ボタンで再開できるように修正

### DIFF
--- a/app/components/PlayerBar.vue
+++ b/app/components/PlayerBar.vue
@@ -303,8 +303,13 @@ function handlePlay() {
   const song = player.currentSong
   if (player.isBlocked) {
     retryPlay()
-  } else if (!player.isPlaying && song && loadedVideoId.value !== song.video.id) {
-    // Video not yet loaded in the iframe — must use requestPlay (load + play)
+  } else if (
+    !player.isPlaying &&
+    song &&
+    (loadedVideoId.value !== song.video.id || player.isAtEnd)
+  ) {
+    // Video not yet loaded in the iframe, or playback ended naturally —
+    // must use requestPlay to (re)load from start_at.
     player.play(song)
     requestPlay(song)
   } else {

--- a/app/components/QueueDrawer.vue
+++ b/app/components/QueueDrawer.vue
@@ -24,7 +24,7 @@
           >
             保存
           </button>
-          <button class="text-xs text-gray-400 hover:text-white" @click="queue.clear()">
+          <button class="text-xs text-gray-400 hover:text-white" @click="playback.clearQueue()">
             クリア
           </button>
           <button class="text-gray-400 hover:text-white" @click="queue.toggleOpen()">
@@ -178,7 +178,7 @@
               <!-- Remove -->
               <button
                 class="shrink-0 text-gray-600 hover:text-white"
-                @click="queue.removeSong(index)"
+                @click="playback.removeSongFromQueue(index)"
               >
                 <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path
@@ -219,7 +219,7 @@
             >
               保存
             </button>
-            <button class="text-xs text-gray-400 hover:text-white" @click="queue.clear()">
+            <button class="text-xs text-gray-400 hover:text-white" @click="playback.clearQueue()">
               クリア
             </button>
             <button class="text-gray-400 hover:text-white" @click="queue.toggleOpen()">
@@ -377,7 +377,7 @@
                 <!-- Remove -->
                 <button
                   class="shrink-0 text-gray-600 hover:text-white"
-                  @click="queue.removeSong(index)"
+                  @click="playback.removeSongFromQueue(index)"
                 >
                   <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path
@@ -413,6 +413,7 @@ import type { Song } from '~/types'
 const queue = useQueueStore()
 const player = usePlayerStore()
 const playlistsStore = usePlaylistsStore()
+const playback = usePlayback()
 
 const draggableQueue = ref<Song[]>([])
 

--- a/app/composables/usePlayback.ts
+++ b/app/composables/usePlayback.ts
@@ -19,7 +19,8 @@ export function usePlayback() {
       player.play(song)
       requestPlay(song)
     } else {
-      player.stop()
+      // End of queue (repeat off): stop playing but keep currentSong so PlayerBar stays visible.
+      player.stopPlayback()
     }
   }
 
@@ -31,5 +32,33 @@ export function usePlayback() {
     }
   }
 
-  return { togglePlay, nextSong, previousSong }
+  /**
+   * Clear the queue and stop playback entirely (including hiding PlayerBar).
+   * Use this instead of calling queue.clear() directly so that player state
+   * stays in sync.
+   */
+  function clearQueue() {
+    queue.clear()
+    player.stop()
+  }
+
+  /**
+   * Remove a song from the queue by index and keep player state in sync.
+   * - If the queue becomes empty: stop playback and hide PlayerBar.
+   * - If the removed song was the current one: sync player.currentSong to the
+   *   new queue.currentSong (display updates without auto-playing).
+   */
+  function removeSongFromQueue(index: number) {
+    queue.removeSong(index)
+    if (queue.songs.length === 0) {
+      player.stop()
+    } else {
+      const current = queue.currentSong
+      if (current && player.currentSong?.id !== current.id) {
+        player.currentSong = current
+      }
+    }
+  }
+
+  return { togglePlay, nextSong, previousSong, clearQueue, removeSongFromQueue }
 }

--- a/app/stores/player.ts
+++ b/app/stores/player.ts
@@ -5,6 +5,8 @@ export const usePlayerStore = defineStore('player', () => {
   const isPlaying = ref(false)
   /** True when the browser blocked autoplay / scripted playback */
   const isBlocked = ref(false)
+  /** True when playback stopped at the natural end of a song (ENDED state). */
+  const isAtEnd = ref(false)
   const currentTime = ref(0)
   const duration = ref(0)
   const volume = ref(100)
@@ -15,6 +17,7 @@ export const usePlayerStore = defineStore('player', () => {
     currentSong.value = song
     isPlaying.value = true
     isBlocked.value = false
+    isAtEnd.value = false
   }
 
   function pause() {
@@ -30,6 +33,20 @@ export const usePlayerStore = defineStore('player', () => {
     currentTime.value = 0
     currentSong.value = null
     isBlocked.value = false
+    isAtEnd.value = false
+  }
+
+  /**
+   * Stop playback without clearing the current song.
+   * Used when the queue reaches its end (repeat off) so that PlayerBar
+   * remains visible and the user can restart or navigate.
+   * Sets isAtEnd so the play button knows to reload from start_at.
+   */
+  function stopPlayback() {
+    isPlaying.value = false
+    currentTime.value = 0
+    isBlocked.value = false
+    isAtEnd.value = true
   }
 
   /** Sync isPlaying with the actual YouTube player state. */
@@ -68,6 +85,7 @@ export const usePlayerStore = defineStore('player', () => {
     currentSong,
     isPlaying,
     isBlocked,
+    isAtEnd,
     currentTime,
     duration,
     volume,
@@ -76,6 +94,7 @@ export const usePlayerStore = defineStore('player', () => {
     pause,
     resume,
     stop,
+    stopPlayback,
     setPlaying,
     setBlocked,
     clearBlocked,

--- a/tests/unit/playerStore.test.ts
+++ b/tests/unit/playerStore.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { Song } from '../../app/types'
+import { usePlayerStore } from '../../app/stores/player'
+import { useQueueStore } from '../../app/stores/queue'
+
+const makeSong = (id: number): Song => ({
+  id,
+  title: `Song ${id}`,
+  artist: `Artist ${id}`,
+  is_original: false,
+  start_at: 0,
+  end_at: 180,
+  video: {
+    id: `video_${id}`,
+    title: `Video ${id}`,
+    url: `https://youtube.com/watch?v=video_${id}`,
+    thumbnail_path: '',
+    is_open: true,
+    is_member_only: false,
+    is_stream: false,
+    unplayable: false,
+    published_at: '2024-01-01T00:00:00Z',
+  },
+})
+
+describe('usePlayerStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('stop()', () => {
+    it('isPlaying, currentSong, currentTime, isBlocked をすべてリセットする', () => {
+      const player = usePlayerStore()
+      player.play(makeSong(1))
+      player.updateTime(60)
+      player.stop()
+      expect(player.isPlaying).toBe(false)
+      expect(player.currentSong).toBeNull()
+      expect(player.currentTime).toBe(0)
+      expect(player.isBlocked).toBe(false)
+    })
+  })
+
+  describe('stopPlayback()', () => {
+    it('isPlaying と currentTime をリセットするが currentSong は残す', () => {
+      const player = usePlayerStore()
+      const song = makeSong(1)
+      player.play(song)
+      player.updateTime(90)
+      player.stopPlayback()
+      expect(player.isPlaying).toBe(false)
+      expect(player.currentTime).toBe(0)
+      expect(player.currentSong).not.toBeNull()
+      expect(player.currentSong?.id).toBe(1)
+      expect(player.isBlocked).toBe(false)
+    })
+
+    it('isAtEnd を true にセットする', () => {
+      const player = usePlayerStore()
+      player.play(makeSong(1))
+      expect(player.isAtEnd).toBe(false)
+      player.stopPlayback()
+      expect(player.isAtEnd).toBe(true)
+    })
+
+    it('isBlocked が true でも stopPlayback() でクリアされる', () => {
+      const player = usePlayerStore()
+      player.play(makeSong(2))
+      player.setBlocked()
+      player.stopPlayback()
+      expect(player.isBlocked).toBe(false)
+      expect(player.currentSong).not.toBeNull()
+    })
+
+    it('play() を呼ぶと isAtEnd がクリアされる', () => {
+      const player = usePlayerStore()
+      player.play(makeSong(1))
+      player.stopPlayback()
+      expect(player.isAtEnd).toBe(true)
+      player.play(makeSong(1))
+      expect(player.isAtEnd).toBe(false)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// End-of-queue sync (Issue #51)
+// ---------------------------------------------------------------------------
+// usePlayback uses useYouTubePlayer which requires a real browser environment,
+// so we test the store-level invariant directly: queue.next() returning null
+// at end of queue must leave queue.currentSong intact.
+
+describe('queue.next() at end of queue (repeat off)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('末尾曲終了後も queue.songs と queue.currentSong が残る', () => {
+    const queue = useQueueStore()
+    queue.setSongs([makeSong(1), makeSong(2)], 1)
+    queue.repeatMode = 'off'
+    const result = queue.next()
+    expect(result).toBeNull()
+    expect(queue.songs.length).toBe(2)
+    expect(queue.currentSong?.id).toBe(2)
+    expect(queue.currentIndex).toBe(1)
+  })
+
+  it('1曲キュー repeat off で next() が null を返し queue は維持される', () => {
+    const queue = useQueueStore()
+    queue.setSongs([makeSong(1)], 0)
+    queue.repeatMode = 'off'
+    const result = queue.next()
+    expect(result).toBeNull()
+    expect(queue.songs.length).toBe(1)
+    expect(queue.currentSong?.id).toBe(1)
+  })
+
+  it('repeat all の場合は末尾から先頭へループして null を返さない', () => {
+    const queue = useQueueStore()
+    queue.setSongs([makeSong(1), makeSong(2)], 1)
+    queue.repeatMode = 'all'
+    const result = queue.next()
+    expect(result).not.toBeNull()
+    expect(queue.currentIndex).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Player + Queue sync for clear / remove (Issue #51)
+// ---------------------------------------------------------------------------
+
+describe('player と queue の同期ルール (Issue #51)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('queue.clear() 後に player.stop() を呼ぶと currentSong が null になる', () => {
+    const player = usePlayerStore()
+    const queue = useQueueStore()
+    queue.setSongs([makeSong(1), makeSong(2)], 0)
+    player.play(makeSong(1))
+    // clearQueue() が行う操作をシミュレート
+    queue.clear()
+    player.stop()
+    expect(queue.songs.length).toBe(0)
+    expect(player.currentSong).toBeNull()
+  })
+
+  it('removeSong でキューが空になったとき player.stop() を呼ぶと currentSong が null になる', () => {
+    const player = usePlayerStore()
+    const queue = useQueueStore()
+    queue.setSongs([makeSong(1)], 0)
+    player.play(makeSong(1))
+    // removeSongFromQueue() が行う操作をシミュレート
+    queue.removeSong(0)
+    if (queue.songs.length === 0) player.stop()
+    expect(queue.songs.length).toBe(0)
+    expect(player.currentSong).toBeNull()
+  })
+
+  it('removeSong で現在曲が削除されたとき player.currentSong が新 currentSong に追従する', () => {
+    const player = usePlayerStore()
+    const queue = useQueueStore()
+    queue.setSongs([makeSong(1), makeSong(2), makeSong(3)], 0)
+    player.play(makeSong(1))
+    // removeSongFromQueue(0) が行う操作をシミュレート
+    queue.removeSong(0)
+    if (queue.songs.length === 0) {
+      player.stop()
+    } else {
+      const current = queue.currentSong
+      if (current && player.currentSong?.id !== current.id) {
+        player.currentSong = current
+      }
+    }
+    expect(queue.songs.length).toBe(2)
+    expect(queue.currentSong?.id).toBe(2)
+    expect(player.currentSong?.id).toBe(2)
+  })
+
+  it('stopPlayback() 後は PlayerBar が維持される (currentSong が残る)', () => {
+    const player = usePlayerStore()
+    player.play(makeSong(1))
+    // 末尾到達時の nextSong() の動作をシミュレート
+    player.stopPlayback()
+    // PlayerBar の v-if="player.currentSong" が true のままであること
+    expect(player.currentSong).not.toBeNull()
+    expect(player.isPlaying).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #51

## 概要

キュー末尾の曲が終了すると `PlayerBar` が消えてしまう状態不整合を修正する。
あわせて、末尾到達後の停止状態で再生ボタンを押しても何も起きない問題も修正。

## 根本原因

`nextSong()` → `queue.next()` が `null` を返す（末尾・repeat off）→ `player.stop()` → `currentSong = null` → `PlayerBar`（`v-if="player.currentSong"`）が非表示になる経路が存在していた。

## 変更内容

### `app/stores/player.ts`

- `stopPlayback()` アクションを追加  
  `stop()` と違い `currentSong` を null にせず、`isPlaying`・`currentTime`・`isBlocked` のみリセットする。PlayerBar を残したまま停止状態を表現するため。
- `isAtEnd` フラグを追加  
  `stopPlayback()` で `true`、`play()` / `stop()` で `false` にリセット。
  末尾停止後の再生ボタン押下時に「再ロードが必要」と判断するために使う。

### `app/composables/usePlayback.ts`

- `nextSong()`: キュー末尾到達時に `player.stop()` → `player.stopPlayback()` に変更
- `clearQueue()` を追加: `queue.clear()` + `player.stop()` をセットで呼ぶ（PlayerBar が消えるべき状況を正しく扱う）
- `removeSongFromQueue(index)` を追加: `queue.removeSong()` 後に `player.currentSong` を新しい currentSong に同期

### `app/components/PlayerBar.vue`

`handlePlay()` の分岐を拡張:

```ts
// 変更前
loadedVideoId.value !== song.video.id

// 変更後
loadedVideoId.value !== song.video.id || player.isAtEnd
```

`isAtEnd` が `true` のとき、`requestPlay(song)` で `start_at` から再ロードして再生する。

### `app/components/QueueDrawer.vue`

デスクトップ・モバイル両方で:
- クリアボタン: `queue.clear()` → `playback.clearQueue()`
- 削除ボタン: `queue.removeSong(index)` → `playback.removeSongFromQueue(index)`

### `tests/unit/playerStore.test.ts`（新規）

12 テストを追加:
- `stop()` の全フィールドリセットを検証
- `stopPlayback()` が `currentSong` を残し `isAtEnd = true` をセットすることを検証
- `play()` で `isAtEnd` がクリアされることを検証
- 末尾到達後も `queue.songs` / `queue.currentSong` が維持されることを検証
- clear / remove 操作後の player 同期を検証
- `stopPlayback()` 後は PlayerBar の `v-if` 条件が `true` を維持することを検証

## 責務整理

| 層 | 役割 |
|---|---|
| `queue` store | キュー内容・現在位置の正本 |
| `player` store | 再生中/停止中/末尾停止、現在時刻などのプレイヤー状態 |
| `usePlayback` | `queue` と `player` を一貫した順序で更新する制御。直接 `queue.clear()` / `queue.removeSong()` を呼ばず `usePlayback` 経由とすることで同期経路を一本化 |
| `PlayerBar` | `player.currentSong` が存在する限り表示。`isAtEnd` を判断して適切な再生方式を選択 |
