### PR TITLE
[ui] スクロールバーの見た目をサイトデザインに合わせる

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -33,3 +33,26 @@
   --color-playing-glow: #ecfccb;
   --color-playing-glow-muted: #a3e635;
 }
+
+/* Scrollbar styling — Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #5a5a5a transparent;
+}
+
+/* Scrollbar styling — Chromium / WebKit */
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #5a5a5a;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--color-selected-text);
+}


### PR DESCRIPTION
## 概要

`app/assets/css/main.css` にカスタムスクロールバースタイルを追加する。
Firefox / Chromium / WebKit の差異を吸収しつつ、既存テーマトークンを使ってダークテーマに統一感を持たせる。

## 変更内容

- **`app/assets/css/main.css`** — scrollbar スタイルを追加（23 行）

| 項目 | 値 |
|------|-----|
| Firefox `scrollbar-width` | `thin` |
| Firefox `scrollbar-color` | `#5a5a5a transparent` |
| Chromium/WebKit `::-webkit-scrollbar` width | `6px` |
| thumb デフォルト色 | `#5a5a5a` |
| thumb hover 色 | `var(--color-selected-text)` = `#d9f99d` |
| track | `transparent` |
| 角丸 | なし（デザイン原則に従いスクエア） |

コンポーネントファイルへの変更はなし。

## 対応方針

- グローバル適用（`*` と `::-webkit-scrollbar*` 擬似要素）で全スクロールコンテナをカバー
- 非対応ブラウザでは標準 UI にフォールバック（CSS を理解しないブラウザは無視するだけ）

Closes #50