### PR TITLE
[ui] インライン SVG アイコンを FontAwesome に置き換える

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 shamefully-hoist=true
+@fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=${FONTAWESOME_TOKEN}

--- a/app/components/AddToPlaylistDropdown.vue
+++ b/app/components/AddToPlaylistDropdown.vue
@@ -5,14 +5,7 @@
       title="プレイリストに追加"
       @click.stop="toggle"
     >
-      <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
-        />
-      </svg>
+      <FontAwesomeIcon :icon="['fas', 'bookmark']" class="h-4 w-4" />
     </button>
 
     <div
@@ -70,14 +63,7 @@
             class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-gray-400 hover:bg-surface-overlay hover:text-white"
             @click="isCreating = true"
           >
-            <svg class="h-3.5 w-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'plus']" class="h-3.5 w-3.5 shrink-0" />
             新規プレイリスト
           </button>
         </div>

--- a/app/components/AppToastRegion.vue
+++ b/app/components/AppToastRegion.vue
@@ -21,34 +21,16 @@
           "
         >
           <!-- Icon -->
-          <svg
+          <FontAwesomeIcon
             v-if="item.type === 'success'"
+            :icon="['fas', 'check']"
             class="mt-0.5 h-4 w-4 shrink-0 text-selected-text"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2.5"
-              d="M5 13l4 4L19 7"
-            />
-          </svg>
-          <svg
+          />
+          <FontAwesomeIcon
             v-else
+            :icon="['fas', 'xmark']"
             class="mt-0.5 h-4 w-4 shrink-0 text-red-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
+          />
 
           <!-- Message -->
           <p class="min-w-0 flex-1 text-sm">
@@ -69,14 +51,7 @@
             aria-label="閉じる"
             @click="store.dismiss(item.id)"
           >
-            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'xmark']" class="h-4 w-4" />
           </button>
         </div>
       </TransitionGroup>

--- a/app/components/PlayerBar.vue
+++ b/app/components/PlayerBar.vue
@@ -21,9 +21,7 @@
           :disabled="!queue.hasPrevious"
           @click="playback.previousSong()"
         >
-          <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M6 6h2v12H6V6zm3.5 6l8.5 6V6l-8.5 6z" />
-          </svg>
+          <FontAwesomeIcon :icon="['fas', 'backward-step']" class="h-5 w-5" />
         </button>
         <button
           class="text-gray-400 hover:text-white"
@@ -31,29 +29,22 @@
           @click="handleMobilePlay"
         >
           <!-- Blocked: show retry icon -->
-          <svg
+          <FontAwesomeIcon
             v-if="player.isBlocked"
+            :icon="['fas', 'arrow-rotate-right']"
             class="h-8 w-8 text-selected-text"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
-            />
-          </svg>
-          <svg v-else class="h-8 w-8" fill="currentColor" viewBox="0 0 24 24">
-            <path v-if="player.isPlaying" d="M6 4h4v16H6V4zm8 0h4v16h-4V4z" />
-            <path v-else d="M8 5v14l11-7z" />
-          </svg>
+          />
+          <template v-else>
+            <FontAwesomeIcon v-if="player.isPlaying" :icon="['fas', 'pause']" class="h-8 w-8" />
+            <FontAwesomeIcon v-else :icon="['fas', 'play']" class="h-8 w-8" />
+          </template>
         </button>
         <button
           class="text-gray-400 hover:text-white disabled:opacity-30"
           :disabled="!queue.hasNext"
           @click="playback.nextSong()"
         >
-          <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M16 6h2v12h-2V6zm-3.5 6L4 6v12l8.5-6z" />
-          </svg>
+          <FontAwesomeIcon :icon="['fas', 'forward-step']" class="h-5 w-5" />
         </button>
 
         <!-- Queue toggle -->
@@ -63,14 +54,7 @@
             :class="queue.isOpen ? 'text-selected-text' : 'text-gray-400 hover:text-white'"
             @click="queue.toggleOpen()"
           >
-            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 6h16M4 10h16M4 14h10"
-              />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'bars']" class="h-5 w-5" />
           </button>
           <span
             v-if="queue.songs.length > 0"
@@ -118,14 +102,7 @@
             :class="queue.shuffleMode ? 'text-selected-text' : 'text-gray-400 hover:text-white'"
             @click="queue.toggleShuffle()"
           >
-            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4"
-              />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'shuffle']" class="h-4 w-4" />
           </button>
 
           <!-- Previous -->
@@ -134,9 +111,7 @@
             :disabled="!queue.hasPrevious"
             @click="playback.previousSong()"
           >
-            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M6 6h2v12H6V6zm3.5 6l8.5 6V6l-8.5 6z" />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'backward-step']" class="h-5 w-5" />
           </button>
 
           <!-- Play/Pause -->
@@ -146,15 +121,15 @@
             @click="handleDesktopPlay"
           >
             <!-- Blocked: show retry icon -->
-            <svg v-if="player.isBlocked" class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-              <path
-                d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
-              />
-            </svg>
-            <svg v-else class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-              <path v-if="player.isPlaying" d="M6 4h4v16H6V4zm8 0h4v16h-4V4z" />
-              <path v-else d="M8 5v14l11-7z" />
-            </svg>
+            <FontAwesomeIcon
+              v-if="player.isBlocked"
+              :icon="['fas', 'arrow-rotate-right']"
+              class="h-5 w-5"
+            />
+            <template v-else>
+              <FontAwesomeIcon v-if="player.isPlaying" :icon="['fas', 'pause']" class="h-5 w-5" />
+              <FontAwesomeIcon v-else :icon="['fas', 'play']" class="h-5 w-5" />
+            </template>
           </button>
 
           <!-- Next -->
@@ -163,9 +138,7 @@
             :disabled="!queue.hasNext"
             @click="playback.nextSong()"
           >
-            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M16 6h2v12h-2V6zm-3.5 6L4 6v12l8.5-6z" />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'forward-step']" class="h-5 w-5" />
           </button>
 
           <!-- Repeat -->
@@ -176,20 +149,7 @@
             "
             @click="queue.cycleRepeatMode()"
           >
-            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 4v5h5M20 20v-5h-5"
-              />
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M20.49 9A9 9 0 005.64 5.64L4 4m16 16l-1.64-1.64A9 9 0 013.51 15"
-              />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'repeat']" class="h-4 w-4" />
             <span
               v-if="queue.repeatMode === 'one'"
               class="absolute -top-1 -right-1 text-[10px] font-bold"
@@ -224,22 +184,12 @@
       <div class="flex items-center gap-3" style="width: 200px; justify-content: flex-end">
         <!-- Volume -->
         <button class="text-gray-400 hover:text-white" @click="player.toggleMute()">
-          <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              v-if="player.isMuted || player.volume === 0"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707A1 1 0 0112 5.586v12.828a1 1 0 01-1.707.707L5.586 15zM17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"
-            />
-            <path
-              v-else
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M15.536 8.464a5 5 0 010 7.072M18.364 5.636a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707A1 1 0 0112 5.586v12.828a1 1 0 01-1.707.707L5.586 15z"
-            />
-          </svg>
+          <FontAwesomeIcon
+            v-if="player.isMuted || player.volume === 0"
+            :icon="['fas', 'volume-xmark']"
+            class="h-5 w-5"
+          />
+          <FontAwesomeIcon v-else :icon="['fas', 'volume-high']" class="h-5 w-5" />
         </button>
         <input
           type="range"
@@ -256,14 +206,7 @@
             :class="queue.isOpen ? 'text-selected-text' : 'text-gray-400 hover:text-white'"
             @click="queue.toggleOpen()"
           >
-            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 6h16M4 10h16M4 14h10"
-              />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'bars']" class="h-5 w-5" />
           </button>
           <span
             v-if="queue.songs.length > 0"

--- a/app/components/QueuePanelContent.vue
+++ b/app/components/QueuePanelContent.vue
@@ -52,26 +52,16 @@
             class="drag-handle flex self-stretch shrink-0 cursor-grab items-center gap-1 active:cursor-grabbing text-gray-600 hover:text-gray-400"
             title="ドラッグで並び替え"
           >
-            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 8h16M4 16h16"
-              />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'grip-vertical']" class="h-4 w-4" />
             <span
               class="w-5 text-center text-xs"
               :class="index === queue.currentIndex ? 'text-selected-text' : 'text-gray-500'"
             >
-              <svg
+              <FontAwesomeIcon
                 v-if="index === queue.currentIndex && player.isPlaying"
+                :icon="['fas', 'volume-high']"
                 class="mx-auto h-3 w-3"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path d="M3 22V2l7 4v12l-7 4zm8 0V6l7 4v8l-7 4zm8 0V10l5 3v6l-5 3z" />
-              </svg>
+              />
               <template v-else>{{ index + 1 }}</template>
             </span>
           </div>
@@ -94,14 +84,7 @@
             class="shrink-0 text-gray-600 hover:text-white"
             @click="playback.removeSongFromQueue(index)"
           >
-            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+            <FontAwesomeIcon :icon="['fas', 'xmark']" class="h-4 w-4" />
           </button>
         </div>
       </VueDraggableNext>

--- a/app/components/SearchBar.vue
+++ b/app/components/SearchBar.vue
@@ -1,18 +1,9 @@
 <template>
   <div class="relative">
-    <svg
+    <FontAwesomeIcon
+      :icon="['fas', 'magnifying-glass']"
       class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-      />
-    </svg>
+    />
     <input
       :value="query"
       type="text"
@@ -30,14 +21,7 @@
       class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white"
       @click="clear"
     >
-      <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M6 18L18 6M6 6l12 12"
-        />
-      </svg>
+      <FontAwesomeIcon :icon="['fas', 'xmark']" class="h-4 w-4" />
     </button>
   </div>
 </template>

--- a/app/components/SideNav.vue
+++ b/app/components/SideNav.vue
@@ -23,14 +23,7 @@
         inuinouta
       </NuxtLink>
       <button class="ml-auto text-gray-400 hover:text-white lg:hidden" @click="close">
-        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M6 18L18 6M6 6l12 12"
-          />
-        </svg>
+        <FontAwesomeIcon :icon="['fas', 'xmark']" class="h-5 w-5" />
       </button>
     </div>
 
@@ -44,9 +37,7 @@
         active-class="!bg-surface-overlay !text-selected-text"
         @click="close"
       >
-        <svg class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="item.icon" />
-        </svg>
+        <FontAwesomeIcon :icon="item.icon" class="h-5 w-5 shrink-0" />
         {{ item.label }}
       </NuxtLink>
     </nav>
@@ -61,37 +52,13 @@ function close() {
   emit('update:open', false)
 }
 
-const navItems = [
-  {
-    to: '/',
-    label: 'ホーム',
-    icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1',
-  },
-  {
-    to: '/songs',
-    label: '楽曲',
-    icon: 'M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z',
-  },
-  {
-    to: '/videos',
-    label: '動画',
-    icon: 'M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z',
-  },
-  {
-    to: '/search',
-    label: '検索',
-    icon: 'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z',
-  },
-  {
-    to: '/playlists',
-    label: 'プレイリスト',
-    icon: 'M4 6h16M4 10h16M4 14h10',
-  },
-  {
-    to: '/about',
-    label: 'このサイトについて',
-    icon: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
-  },
+const navItems: { to: string; label: string; icon: [string, string] }[] = [
+  { to: '/', label: 'ホーム', icon: ['fas', 'house'] },
+  { to: '/songs', label: '楽曲', icon: ['fas', 'music'] },
+  { to: '/videos', label: '動画', icon: ['fas', 'video'] },
+  { to: '/search', label: '検索', icon: ['fas', 'magnifying-glass'] },
+  { to: '/playlists', label: 'プレイリスト', icon: ['fas', 'list'] },
+  { to: '/about', label: 'このサイトについて', icon: ['fas', 'circle-info'] },
 ]
 </script>
 

--- a/app/components/SongCard.vue
+++ b/app/components/SongCard.vue
@@ -15,13 +15,10 @@
       <div
         class="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/40"
       >
-        <svg
+        <FontAwesomeIcon
+          :icon="['fas', 'play']"
           class="h-10 w-10 text-white opacity-0 transition-opacity group-hover:opacity-100"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path d="M8 5v14l11-7z" />
-        </svg>
+        />
       </div>
       <!-- Duration badge -->
       <span class="absolute bottom-1 right-1 bg-black/80 px-1.5 py-0.5 text-xs text-gray-200">

--- a/app/components/SongListItem.vue
+++ b/app/components/SongListItem.vue
@@ -10,14 +10,11 @@
       class="w-8 shrink-0 text-center text-xs"
       :class="isActive ? 'text-selected-text' : 'text-gray-500'"
     >
-      <svg
+      <FontAwesomeIcon
         v-if="isActive && player.isPlaying"
+        :icon="['fas', 'volume-high']"
         class="mx-auto h-3.5 w-3.5"
-        fill="currentColor"
-        viewBox="0 0 24 24"
-      >
-        <path d="M3 22V2l7 4v12l-7 4zm8 0V6l7 4v8l-7 4zm8 0V10l5 3v6l-5 3z" />
-      </svg>
+      />
       <template v-else>{{ index + 1 }}</template>
     </span>
 
@@ -36,9 +33,7 @@
         v-if="!showIndex && isActive && player.isPlaying"
         class="absolute inset-0 flex items-center justify-center bg-black/60"
       >
-        <svg class="h-4 w-4 text-selected-text" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M3 22V2l7 4v12l-7 4zm8 0V6l7 4v8l-7 4zm8 0V10l5 3v6l-5 3z" />
-        </svg>
+        <FontAwesomeIcon :icon="['fas', 'volume-high']" class="h-4 w-4 text-selected-text" />
       </div>
     </div>
 
@@ -66,28 +61,14 @@
         title="次に再生"
         @click.stop="queueActions.playNext(song)"
       >
-        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M11.25 4.5l7.5 7.5-7.5 7.5m-6-15l7.5 7.5-7.5 7.5"
-          />
-        </svg>
+        <FontAwesomeIcon :icon="['fas', 'angles-right']" class="h-4 w-4" />
       </button>
       <button
         class="p-1 text-gray-400 hover:text-white"
         title="キューに追加"
         @click.stop="queueActions.addToQueue(song)"
       >
-        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-          />
-        </svg>
+        <FontAwesomeIcon :icon="['fas', 'plus']" class="h-4 w-4" />
       </button>
     </div>
   </div>

--- a/app/components/VideoCard.vue
+++ b/app/components/VideoCard.vue
@@ -14,14 +14,10 @@
       <div
         class="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/40"
       >
-        <svg
+        <FontAwesomeIcon
+          :icon="['fas', 'chevron-right']"
           class="h-8 w-8 text-white opacity-0 transition-opacity group-hover:opacity-100"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-        </svg>
+        />
       </div>
       <!-- Song count badge -->
       <span class="absolute bottom-1 right-1 bg-black/80 px-1.5 py-0.5 text-xs text-gray-200">

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -3,14 +3,7 @@
     <!-- Mobile header -->
     <header class="flex h-14 items-center gap-3 border-b border-border-default px-4 lg:hidden">
       <button class="hover:text-selected-text text-accent" @click="sideNavOpen = true">
-        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M4 6h16M4 12h16M4 18h16"
-          />
-        </svg>
+        <FontAwesomeIcon :icon="['fas', 'bars']" class="h-6 w-6" />
       </button>
       <NuxtLink to="/" class="text-lg font-bold">inuinouta</NuxtLink>
       <div class="flex-1" />

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -5,7 +5,8 @@
     <!-- About this site -->
     <section class="mb-8">
       <h2 class="mb-3 border-b border-border-default pb-2 text-base font-bold text-gray-50">
-        🎵 いぬいのうたについて
+        <FontAwesomeIcon :icon="['fas', 'music']" class="mr-2 h-4 w-4 text-gray-400" />
+        いぬいのうたについて
       </h2>
       <div class="space-y-3 text-sm leading-relaxed">
         <p class="text-gray-400">
@@ -30,7 +31,8 @@
     <!-- Features -->
     <section class="mb-8">
       <h2 class="mb-3 border-b border-border-default pb-2 text-base font-bold text-gray-50">
-        ✨ 主な機能
+        <FontAwesomeIcon :icon="['fas', 'star']" class="mr-2 h-4 w-4 text-gray-400" />
+        主な機能
       </h2>
       <ul class="list-inside list-disc space-y-2 text-sm text-gray-400">
         <li>楽曲・歌枠配信の検索と視聴</li>
@@ -43,7 +45,8 @@
     <!-- Tech stack -->
     <section class="mb-8">
       <h2 class="mb-3 border-b border-border-default pb-2 text-base font-bold text-gray-50">
-        ⚙️ 技術スタック
+        <FontAwesomeIcon :icon="['fas', 'gear']" class="mr-2 h-4 w-4 text-gray-400" />
+        技術スタック
       </h2>
       <div class="space-y-2 text-sm">
         <div>
@@ -60,7 +63,8 @@
     <!-- Related links -->
     <section class="mb-8">
       <h2 class="mb-3 border-b border-border-default pb-2 text-base font-bold text-gray-50">
-        🔗 関連リンク
+        <FontAwesomeIcon :icon="['fas', 'link']" class="mr-2 h-4 w-4 text-gray-400" />
+        関連リンク
       </h2>
       <div class="space-y-2 text-sm">
         <a
@@ -69,7 +73,7 @@
           rel="noopener noreferrer"
           class="flex items-center gap-2 text-selected-text hover:underline"
         >
-          <span>📺</span>
+          <FontAwesomeIcon :icon="['fab', 'youtube']" class="h-4 w-4" />
           <span>戌亥とこ YouTubeチャンネル</span>
         </a>
         <a
@@ -78,7 +82,7 @@
           rel="noopener noreferrer"
           class="flex items-center gap-2 text-selected-text hover:underline"
         >
-          <span>🐦</span>
+          <FontAwesomeIcon :icon="['fab', 'x-twitter']" class="h-4 w-4" />
           <span>戌亥とこ Twitter</span>
         </a>
       </div>
@@ -87,7 +91,8 @@
     <!-- Contact -->
     <section class="mb-8">
       <h2 class="mb-3 border-b border-border-default pb-2 text-base font-bold text-gray-50">
-        📧 連絡先
+        <FontAwesomeIcon :icon="['fas', 'envelope']" class="mr-2 h-4 w-4 text-gray-400" />
+        連絡先
       </h2>
       <div class="space-y-2 text-sm">
         <div>

--- a/app/pages/playlists/[id].vue
+++ b/app/pages/playlists/[id].vue
@@ -5,9 +5,7 @@
       to="/playlists"
       class="mb-4 inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white"
     >
-      <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-      </svg>
+      <FontAwesomeIcon :icon="['fas', 'chevron-left']" class="h-4 w-4" />
       プレイリスト一覧
     </NuxtLink>
 
@@ -120,14 +118,7 @@
               class="drag-handle flex shrink-0 cursor-grab items-center justify-center px-1 text-gray-600 hover:text-gray-400 active:cursor-grabbing"
               title="ドラッグで並び替え"
             >
-              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M4 8h16M4 16h16"
-                />
-              </svg>
+              <FontAwesomeIcon :icon="['fas', 'grip-vertical']" class="h-4 w-4" />
             </div>
 
             <!-- Song row (reusing SongListItem) -->
@@ -144,14 +135,7 @@
                     title="プレイリストから削除"
                     @click.stop="handleRemoveSong(index)"
                   >
-                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                      />
-                    </svg>
+                    <FontAwesomeIcon :icon="['fas', 'trash']" class="h-4 w-4" />
                   </button>
                 </template>
               </SongListItem>

--- a/app/pages/playlists/index.vue
+++ b/app/pages/playlists/index.vue
@@ -49,19 +49,7 @@
         class="group flex items-center gap-4 border-b border-border-default px-3 py-3 transition-colors hover:bg-surface-overlay"
       >
         <!-- List icon -->
-        <svg
-          class="h-5 w-5 shrink-0 text-gray-500"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M4 6h16M4 10h16M4 14h10"
-          />
-        </svg>
+        <FontAwesomeIcon :icon="['fas', 'list']" class="h-5 w-5 shrink-0 text-gray-500" />
 
         <!-- Info -->
         <div class="min-w-0 flex-1">
@@ -73,32 +61,16 @@
         <span class="shrink-0 text-xs text-gray-400">{{ pl.items.length }}曲</span>
 
         <!-- Chevron -->
-        <svg
+        <FontAwesomeIcon
+          :icon="['fas', 'chevron-right']"
           class="h-4 w-4 shrink-0 text-gray-600 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-        </svg>
+        />
       </NuxtLink>
     </div>
 
     <!-- Empty state -->
     <div v-else-if="!isCreating" class="px-4 py-16 text-center">
-      <svg
-        class="mx-auto mb-4 h-16 w-16 text-gray-600"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="1.5"
-          d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"
-        />
-      </svg>
+      <FontAwesomeIcon :icon="['fas', 'music']" class="mx-auto mb-4 h-16 w-16 text-gray-600" />
       <p class="text-sm text-gray-400">プレイリストがありません</p>
       <p class="mt-1 text-xs text-gray-500">再生キューから保存してみましょう</p>
     </div>
@@ -108,19 +80,10 @@
       v-if="playlistsStore.playlists.length > 0"
       class="mt-6 flex items-start gap-2 border border-border-default px-4 py-3 text-sm text-gray-400"
     >
-      <svg
+      <FontAwesomeIcon
+        :icon="['fas', 'circle-info']"
         class="mt-0.5 h-4 w-4 shrink-0 text-gray-500"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-        />
-      </svg>
+      />
       <p>
         プレイリストはこのブラウザに保存されます。別のデバイスやブラウザからはアクセスできません。
       </p>

--- a/app/pages/videos/[id].vue
+++ b/app/pages/videos/[id].vue
@@ -38,7 +38,8 @@
             rel="noopener noreferrer"
             class="border border-border-default px-5 py-2 text-sm text-gray-300 transition-colors hover:bg-surface-overlay hover:text-white"
           >
-            YouTubeで見る ↗
+            YouTubeで見る
+            <FontAwesomeIcon :icon="['fas', 'arrow-up-right-from-square']" class="ml-1 h-3 w-3" />
           </a>
         </div>
       </div>

--- a/app/plugins/fontawesome.ts
+++ b/app/plugins/fontawesome.ts
@@ -1,0 +1,78 @@
+import { library, config } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import {
+  faHouse,
+  faMusic,
+  faVideo,
+  faMagnifyingGlass,
+  faList,
+  faCircleInfo,
+  faPlay,
+  faPause,
+  faBackwardStep,
+  faForwardStep,
+  faShuffle,
+  faRepeat,
+  faArrowRotateRight,
+  faBars,
+  faXmark,
+  faGripVertical,
+  faVolumeHigh,
+  faVolumeXmark,
+  faPlus,
+  faBookmark,
+  faCheck,
+  faChevronRight,
+  faChevronLeft,
+  faTrash,
+  faAnglesRight,
+  faLink,
+  faEnvelope,
+  faStar,
+  faArrowUpRightFromSquare,
+  faGear,
+} from '@fortawesome/free-solid-svg-icons'
+import { faYoutube, faXTwitter } from '@fortawesome/free-brands-svg-icons'
+
+// Prevent double CSS loading — managed via nuxt.config.ts css[]
+config.autoAddCss = false
+
+library.add(
+  faHouse,
+  faMusic,
+  faVideo,
+  faMagnifyingGlass,
+  faList,
+  faCircleInfo,
+  faPlay,
+  faPause,
+  faBackwardStep,
+  faForwardStep,
+  faShuffle,
+  faRepeat,
+  faArrowRotateRight,
+  faBars,
+  faXmark,
+  faGripVertical,
+  faVolumeHigh,
+  faVolumeXmark,
+  faPlus,
+  faBookmark,
+  faCheck,
+  faChevronRight,
+  faChevronLeft,
+  faTrash,
+  faAnglesRight,
+  faLink,
+  faEnvelope,
+  faStar,
+  faArrowUpRightFromSquare,
+  faGear,
+  // Brands
+  faYoutube,
+  faXTwitter,
+)
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.component('FontAwesomeIcon', FontAwesomeIcon)
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,16 @@ export default defineNuxtConfig({
 
   ssr: true,
 
-  css: ['~/assets/css/main.css'],
+  css: ['~/assets/css/main.css', '@fortawesome/fontawesome-svg-core/styles.css'],
+
+  build: {
+    transpile: [
+      '@fortawesome/fontawesome-svg-core',
+      '@fortawesome/free-solid-svg-icons',
+      '@fortawesome/free-brands-svg-icons',
+      '@fortawesome/vue-fontawesome',
+    ],
+  },
 
   modules: ['@nuxtjs/google-fonts', '@nuxt/eslint', '@pinia/nuxt'],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.2.0",
+    "@fortawesome/free-brands-svg-icons": "^7.2.0",
+    "@fortawesome/free-solid-svg-icons": "^7.2.0",
+    "@fortawesome/vue-fontawesome": "^3.1.3",
     "@pinia/nuxt": "^0.11.3",
     "nuxt": "^4.4.2",
     "pinia": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@fortawesome/fontawesome-svg-core':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@fortawesome/free-brands-svg-icons':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@fortawesome/free-solid-svg-icons':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@fortawesome/vue-fontawesome':
+        specifier: ^3.1.3
+        version: 3.1.3(@fortawesome/fontawesome-svg-core@7.2.0)(vue@3.5.30(typescript@5.9.3))
       '@pinia/nuxt':
         specifier: ^0.11.3
         version: 0.11.3(magicast@0.5.2)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3)))
@@ -464,6 +476,28 @@ packages:
   '@eslint/plugin-kit@0.6.1':
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@fortawesome/fontawesome-common-types@7.2.0':
+    resolution: {integrity: sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    resolution: {integrity: sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/free-brands-svg-icons@7.2.0':
+    resolution: {integrity: sha512-VNG8xqOip1JuJcC3zsVsKRQ60oXG9+oYNDCosjoU/H9pgYmLTEwWw8pE0jhPz/JWdHeUuK6+NQ3qsM4gIbdbYQ==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/free-solid-svg-icons@7.2.0':
+    resolution: {integrity: sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/vue-fontawesome@3.1.3':
+    resolution: {integrity: sha512-OHHUTLPEzdwP8kcYIzhioUdUOjZ4zzmi+midwa4bqscza4OJCOvTKJEHkXNz8PgZ23kWci1HkKVX0bm8f9t9gQ==}
+    peerDependencies:
+      '@fortawesome/fontawesome-svg-core': ~1 || ~6 || ~7
+      vue: '>= 3.0.0 < 4'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5044,6 +5078,25 @@ snapshots:
     dependencies:
       '@eslint/core': 1.1.1
       levn: 0.4.1
+
+  '@fortawesome/fontawesome-common-types@7.2.0': {}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/free-brands-svg-icons@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/free-solid-svg-icons@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/vue-fontawesome@3.1.3(@fortawesome/fontawesome-svg-core@7.2.0)(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@fortawesome/fontawesome-svg-core': 7.2.0
+      vue: 3.5.30(typescript@5.9.3)
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
## 概要

Closes #49

v4 の主要 UI アイコン（インライン SVG・絵文字）を FontAwesome Free に統一し、保守しやすいアイコン利用形に揃えました。

## 変更内容

### セットアップ
- `@fortawesome/fontawesome-svg-core`, `free-solid-svg-icons`, `free-brands-svg-icons`, `vue-fontawesome` を追加
- `app/plugins/fontawesome.ts` を新規作成: アイコンを `library.add` で登録し、`FontAwesomeIcon` をグローバルコンポーネントとして登録
- `nuxt.config.ts` に FA CSS の読み込み（`autoAddCss = false` 対応）と `build.transpile` を追加

### アイコン置き換えコンポーネント
| ファイル | 内容 |
|---------|------|
| `SideNav.vue` | ナビアイコン（`navItems` の SVG パス文字列 → FA アイコン定義）、閉じるボタン |
| `PlayerBar.vue` | 再生/停止/前後/シャッフル/リピート/音量/キューボタン（モバイル・デスクトップ両方） |
| `QueuePanelContent.vue` | ドラッグハンドル、再生中インジケーター、削除ボタン |
| `SongListItem.vue` | 再生中インジケーター、次に再生・キュー追加ボタン |
| `SongCard.vue` | ホバーオーバーレイの再生アイコン |
| `VideoCard.vue` | ホバーオーバーレイの矢印アイコン |
| `SearchBar.vue` | 検索アイコン、クリアボタン |
| `AppToastRegion.vue` | 成功/エラーアイコン、閉じるボタン |
| `AddToPlaylistDropdown.vue` | ブックマークアイコン、新規作成ボタン |
| `layouts/default.vue` | ハンバーガーメニューボタン |
| `pages/playlists/index.vue` | リストアイコン、シェブロン、空状態の音楽アイコン、インフォアイコン |
| `pages/playlists/[id].vue` | 戻るシェブロン、ドラッグハンドル、削除ボタン |
| `pages/about.vue` | セクション見出し絵文字、関連リンクアイコン（YouTube・X） |
| `pages/videos/[id].vue` | 「YouTubeで見る ↗」の外部リンクアイコン |

### 使用アイコンセット
- `free-solid-svg-icons`（主軸）
- `free-brands-svg-icons`（YouTube・X Twitter ロゴ）

## 確認事項

- [x] `config.autoAddCss = false` で hydration ミスマッチ回避
- [x] lint / build が通る
- [x] インライン SVG・絵文字が主要 UI から除去された（`grep` で残存なし確認済み）