### PR TITLE
feat: 動画詳細ページの楽曲行にプレイリスト追加とキュー操作を追加 #73

### DIFF
--- a/app/components/SongRowActions.vue
+++ b/app/components/SongRowActions.vue
@@ -1,0 +1,31 @@
+<template>
+  <div
+    class="flex shrink-0 gap-2 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:[&:has(.dropdown-open)]:opacity-100"
+  >
+    <AddToPlaylistDropdown :song-id="song.id" :song-title="song.title" />
+    <button
+      class="p-1 text-gray-400 hover:text-white"
+      title="次に再生"
+      @click.stop="queueActions.playNext(song)"
+    >
+      <FontAwesomeIcon :icon="['fas', 'angles-right']" class="h-4 w-4" />
+    </button>
+    <button
+      class="p-1 text-gray-400 hover:text-white"
+      title="キューに追加"
+      @click.stop="queueActions.addToQueue(song)"
+    >
+      <FontAwesomeIcon :icon="['fas', 'plus']" class="h-4 w-4" />
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Song } from '~/types'
+
+defineProps<{
+  song: Song
+}>()
+
+const queueActions = useQueueActions()
+</script>

--- a/app/pages/videos/[id].vue
+++ b/app/pages/videos/[id].vue
@@ -54,14 +54,15 @@
         class="group flex cursor-pointer items-center gap-3 border-b border-border-default px-3 py-2 transition-colors hover:bg-surface-overlay"
         @click="playSongFromVideo(index)"
       >
-        <span class="w-8 text-center text-xs text-gray-500">{{ index + 1 }}</span>
+        <span class="w-8 shrink-0 text-center text-xs text-gray-500">{{ index + 1 }}</span>
         <div class="min-w-0 flex-1">
           <p class="truncate text-sm font-medium">{{ s.title }}</p>
           <p class="truncate text-xs text-gray-500">{{ s.artist ?? '不明' }}</p>
         </div>
-        <span class="shrink-0 text-xs text-gray-500">
+        <span class="hidden shrink-0 text-xs text-gray-500 sm:inline">
           {{ songDuration(s.start_at, s.end_at) }}
         </span>
+        <SongRowActions :song="songs[index]" />
       </div>
     </section>
   </div>
@@ -84,7 +85,7 @@ useHead({
 })
 
 /** Convert video's SongBasic[] to Song[] by injecting the video reference */
-function toSongs(): Song[] {
+const songs = computed<Song[]>(() => {
   if (!video.value) return []
   const v = video.value
   return v.songs.map((s) => ({
@@ -101,13 +102,13 @@ function toSongs(): Song[] {
       published_at: v.published_at,
     },
   }))
-}
+})
 
 function playVideoSongs() {
-  queueActions.playAll(toSongs())
+  queueActions.playAll(songs.value)
 }
 
 function playSongFromVideo(index: number) {
-  queueActions.playAll(toSongs(), index)
+  queueActions.playAll(songs.value, index)
 }
 </script>


### PR DESCRIPTION
## 概要

動画詳細ページ (`/videos/[id]`) の各楽曲行から、プレイリスト追加・次に再生・キューに追加ができるようにしました。

Closes #73

## 変更内容

### 新規: `app/components/SongRowActions.vue`

- `song: Song` を受け取る楽曲行アクションコンポーネント
- AddToPlaylistDropdown + 次に再生ボタン + キューに追加ボタンの 3 アクション
- デスクトップ: hover で表示 (`sm:opacity-0 sm:group-hover:opacity-100`)
- モバイル: 常時表示
- ドロップダウン展開中は非表示にならない (`sm:[&:has(.dropdown-open)]:opacity-100`)
- ボタンはすべて `@click.stop` 済みで行クリック再生と競合しない

### 変更: `app/pages/videos/[id].vue`

| 変更点 | 内容 |
|---|---|
| 楽曲行に `<SongRowActions>` 追加 | `:song="songs[index]"` で `Song` モデル（video フィールド埋め込み済み）を渡す |
| `toSongs()` → `songs` computed | 毎回再計算しない形に変換 |
| duration に `hidden sm:inline` 追加 | モバイルでアクションと競合しないよう非表示化 |
| インデックス span に `shrink-0` 追加 | 行が狭い時に番号が潰れないよう修正 |

## テスト

- ESLint: エラーなし
- unit tests: 79 passed

## スクリーンショット

手動でデスクトップ・モバイル幅にてご確認ください。