### PR TITLE
feat: ランダム再生をキューシャッフル仕様に変更 (#77)

### DIFF
--- a/app/components/MobileNowPlayingOverlay.vue
+++ b/app/components/MobileNowPlayingOverlay.vue
@@ -68,8 +68,9 @@
         <div class="flex items-center justify-center gap-6 py-3">
           <!-- Shuffle -->
           <button
-            :class="queue.shuffleMode ? 'text-selected-text' : 'text-gray-400 hover:text-white'"
-            @click="queue.toggleShuffle()"
+            class="text-gray-400 hover:text-white disabled:opacity-30"
+            :disabled="queue.songs.length <= 1"
+            @click="handleShuffle()"
           >
             <FontAwesomeIcon :icon="['fas', 'shuffle']" class="h-4 w-4" />
           </button>
@@ -212,6 +213,12 @@
 const player = usePlayerStore()
 const queue = useQueueStore()
 const overlay = useMobileNowPlayingOverlay()
+const { success } = useNotifications()
+
+function handleShuffle() {
+  queue.shuffleQueue()
+  success('キューをシャッフルしました')
+}
 const playback = usePlayback()
 const { formatTime, songDuration } = useFormatTime()
 const { seekTo, retryPlay, requestPlay, loadedVideoId } = useYouTubePlayer()

--- a/app/components/PlayerBar.vue
+++ b/app/components/PlayerBar.vue
@@ -105,8 +105,9 @@
         <div class="flex items-center gap-4">
           <!-- Shuffle -->
           <button
-            :class="queue.shuffleMode ? 'text-selected-text' : 'text-gray-400 hover:text-white'"
-            @click="queue.toggleShuffle()"
+            class="text-gray-400 hover:text-white disabled:opacity-30"
+            :disabled="queue.songs.length <= 1"
+            @click="handleShuffle()"
           >
             <FontAwesomeIcon :icon="['fas', 'shuffle']" class="h-4 w-4" />
           </button>
@@ -230,6 +231,12 @@
 const player = usePlayerStore()
 const queue = useQueueStore()
 const playback = usePlayback()
+const { success } = useNotifications()
+
+function handleShuffle() {
+  queue.shuffleQueue()
+  success('キューをシャッフルしました')
+}
 const { formatTime, songDuration } = useFormatTime()
 const { seekTo, retryPlay, requestPlay, loadedVideoId } = useYouTubePlayer()
 const mobileOverlay = useMobileNowPlayingOverlay()

--- a/app/plugins/playback-persistence.client.ts
+++ b/app/plugins/playback-persistence.client.ts
@@ -7,7 +7,6 @@ const SETTINGS_STORAGE_KEY = 'playback:settings'
 interface PersistedQueue {
   songs: Song[]
   currentIndex: number
-  shuffleMode: boolean
   repeatMode: RepeatMode
 }
 
@@ -48,7 +47,7 @@ export default defineNuxtPlugin(() => {
     }
   }
 
-  // Restore queue state (songs, index, shuffle, repeat)
+  // Restore queue state (songs, currentIndex, repeat)
   const persistedQueue = loadJson<PersistedQueue>(QUEUE_STORAGE_KEY)
   if (persistedQueue && Array.isArray(persistedQueue.songs) && persistedQueue.songs.length > 0) {
     const validIndex =
@@ -61,9 +60,6 @@ export default defineNuxtPlugin(() => {
     queue.setSongs(persistedQueue.songs, validIndex)
 
     const validRepeatModes: RepeatMode[] = ['off', 'all', 'one']
-    if (typeof persistedQueue.shuffleMode === 'boolean') {
-      queue.shuffleMode = persistedQueue.shuffleMode
-    }
     if (validRepeatModes.includes(persistedQueue.repeatMode)) {
       queue.repeatMode = persistedQueue.repeatMode
     }
@@ -81,7 +77,6 @@ export default defineNuxtPlugin(() => {
     () => ({
       songs: queue.songs,
       currentIndex: queue.currentIndex,
-      shuffleMode: queue.shuffleMode,
       repeatMode: queue.repeatMode,
     }),
     (state) => {

--- a/app/stores/queue.ts
+++ b/app/stores/queue.ts
@@ -5,7 +5,6 @@ export type RepeatMode = 'off' | 'all' | 'one'
 export const useQueueStore = defineStore('queue', () => {
   const songs = ref<Song[]>([])
   const currentIndex = ref(-1)
-  const shuffleMode = ref(false)
   const repeatMode = ref<RepeatMode>('off')
   const isOpen = ref(false)
 
@@ -64,9 +63,7 @@ export const useQueueStore = defineStore('queue', () => {
   function next(): Song | null {
     if (songs.value.length === 0) return null
     if (repeatMode.value === 'one') return currentSong.value
-    if (shuffleMode.value) {
-      currentIndex.value = Math.floor(Math.random() * songs.value.length)
-    } else if (currentIndex.value < songs.value.length - 1) {
+    if (currentIndex.value < songs.value.length - 1) {
       currentIndex.value++
     } else if (repeatMode.value === 'all') {
       currentIndex.value = 0
@@ -86,8 +83,17 @@ export const useQueueStore = defineStore('queue', () => {
     return currentSong.value
   }
 
-  function toggleShuffle() {
-    shuffleMode.value = !shuffleMode.value
+  function shuffleQueue() {
+    if (songs.value.length <= 1) return
+    const current = songs.value[currentIndex.value]
+    const rest = songs.value.filter((_, i) => i !== currentIndex.value)
+    // Fisher-Yates shuffle
+    for (let i = rest.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[rest[i], rest[j]] = [rest[j], rest[i]]
+    }
+    songs.value = [current, ...rest]
+    currentIndex.value = 0
   }
 
   function cycleRepeatMode() {
@@ -125,7 +131,6 @@ export const useQueueStore = defineStore('queue', () => {
   return {
     songs,
     currentIndex,
-    shuffleMode,
     repeatMode,
     isOpen,
     currentSong,
@@ -140,7 +145,7 @@ export const useQueueStore = defineStore('queue', () => {
     clear,
     next,
     previous,
-    toggleShuffle,
+    shuffleQueue,
     cycleRepeatMode,
     toggleOpen,
   }

--- a/tests/unit/playbackPersistence.test.ts
+++ b/tests/unit/playbackPersistence.test.ts
@@ -67,7 +67,6 @@ function simulateRestore(
 
         queue.setSongs(persisted.songs, validIndex)
 
-        if (typeof persisted.shuffleMode === 'boolean') queue.shuffleMode = persisted.shuffleMode
         const validModes = ['off', 'all', 'one']
         if (validModes.includes(persisted.repeatMode)) queue.repeatMode = persisted.repeatMode
 
@@ -107,27 +106,20 @@ describe('playback persistence (Issue #18)', () => {
       expect(queue.currentIndex).toBe(1)
     })
 
-    it('repeatMode と shuffleMode が復元される', () => {
+    it('repeatMode が復元される', () => {
       const songs = [makeSong(1)]
-      localStorage.setItem(
-        QUEUE_KEY,
-        JSON.stringify({ songs, currentIndex: 0, shuffleMode: true, repeatMode: 'all' }),
-      )
+      localStorage.setItem(QUEUE_KEY, JSON.stringify({ songs, currentIndex: 0, repeatMode: 'all' }))
 
       const queue = useQueueStore()
       const player = usePlayerStore()
       simulateRestore(queue, player)
 
-      expect(queue.shuffleMode).toBe(true)
       expect(queue.repeatMode).toBe('all')
     })
 
     it('復元後に player.currentSong が queue.currentSong と一致する（PlayerBar 表示可）', () => {
       const songs = [makeSong(10), makeSong(20)]
-      localStorage.setItem(
-        QUEUE_KEY,
-        JSON.stringify({ songs, currentIndex: 1, shuffleMode: false, repeatMode: 'off' }),
-      )
+      localStorage.setItem(QUEUE_KEY, JSON.stringify({ songs, currentIndex: 1, repeatMode: 'off' }))
 
       const queue = useQueueStore()
       const player = usePlayerStore()
@@ -139,10 +131,7 @@ describe('playback persistence (Issue #18)', () => {
 
     it('自動再生されない（isPlaying が false のまま）', () => {
       const songs = [makeSong(1)]
-      localStorage.setItem(
-        QUEUE_KEY,
-        JSON.stringify({ songs, currentIndex: 0, shuffleMode: false, repeatMode: 'off' }),
-      )
+      localStorage.setItem(QUEUE_KEY, JSON.stringify({ songs, currentIndex: 0, repeatMode: 'off' }))
 
       const queue = useQueueStore()
       const player = usePlayerStore()
@@ -206,7 +195,7 @@ describe('playback persistence (Issue #18)', () => {
       const songs = [makeSong(1), makeSong(2)]
       localStorage.setItem(
         QUEUE_KEY,
-        JSON.stringify({ songs, currentIndex: 99, shuffleMode: false, repeatMode: 'off' }),
+        JSON.stringify({ songs, currentIndex: 99, repeatMode: 'off' }),
       )
 
       const queue = useQueueStore()
@@ -220,7 +209,7 @@ describe('playback persistence (Issue #18)', () => {
       const songs = [makeSong(1)]
       localStorage.setItem(
         QUEUE_KEY,
-        JSON.stringify({ songs, currentIndex: 0, shuffleMode: false, repeatMode: 'invalid' }),
+        JSON.stringify({ songs, currentIndex: 0, repeatMode: 'invalid' }),
       )
 
       const queue = useQueueStore()
@@ -229,6 +218,20 @@ describe('playback persistence (Issue #18)', () => {
 
       // repeatMode should remain the default 'off'
       expect(queue.repeatMode).toBe('off')
+    })
+
+    it('旧 shuffleMode データが残っていても璴命的に壊れない', () => {
+      const songs = [makeSong(1), makeSong(2), makeSong(3)]
+      localStorage.setItem(
+        QUEUE_KEY,
+        JSON.stringify({ songs, currentIndex: 0, shuffleMode: true, repeatMode: 'off' }),
+      )
+
+      const queue = useQueueStore()
+      const player = usePlayerStore()
+      expect(() => simulateRestore(queue, player)).not.toThrow()
+      expect(queue.songs).toHaveLength(3)
+      expect(queue.currentIndex).toBe(0)
     })
   })
 })

--- a/tests/unit/queueStore.test.ts
+++ b/tests/unit/queueStore.test.ts
@@ -114,4 +114,50 @@ describe('useQueueStore', () => {
       expect(queue.totalDuration).toBe('1時間1分')
     })
   })
+
+  // --- shuffleQueue ---
+
+  describe('shuffleQueue', () => {
+    it('現在再生中の曲が index 0 へ移動する', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3), makeSong(4)], 2)
+      const currentId = queue.currentSong?.id
+      queue.shuffleQueue()
+      expect(queue.currentIndex).toBe(0)
+      expect(queue.currentSong?.id).toBe(currentId)
+    })
+
+    it('曲数と内容が欠けない', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3), makeSong(4), makeSong(5)], 0)
+      queue.shuffleQueue()
+      expect(queue.songs).toHaveLength(5)
+      const sortedIds = queue.songs.map((s) => s.id).sort((a, b) => a - b)
+      expect(sortedIds).toEqual([1, 2, 3, 4, 5])
+    })
+
+    it('シャッフル後の next() がキュー順と一致する', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1), makeSong(2), makeSong(3)], 1)
+      queue.shuffleQueue()
+      const secondId = queue.songs[1]?.id
+      queue.next()
+      expect(queue.currentSong?.id).toBe(secondId)
+    })
+
+    it('曲が 1 曲のときは no-op', () => {
+      const queue = useQueueStore()
+      queue.setSongs([makeSong(1)], 0)
+      queue.shuffleQueue()
+      expect(queue.songs).toHaveLength(1)
+      expect(queue.currentIndex).toBe(0)
+    })
+
+    it('曲が 0 曲のときは no-op', () => {
+      const queue = useQueueStore()
+      queue.shuffleQueue()
+      expect(queue.songs).toHaveLength(0)
+      expect(queue.currentIndex).toBe(-1)
+    })
+  })
 })


### PR DESCRIPTION
Closes #77

## 変更概要

ランダム再生を `shuffleMode` のトグルではなく、**現在再生中の曲を先頭に固定したキューシャッフル**に変更する。

## 変更内容

### `app/stores/queue.ts`
- `shuffleMode` ref を削除
- `next()` からランダム分岐（`shuffleMode` 参照）を除去 → 常にキュー順で進む
- `toggleShuffle()` を削除し `shuffleQueue()` を追加
  - 現在曲を先頭に固定し、残り曲を Fisher-Yates でシャッフル
  - シャッフル後に `currentIndex = 0`

### `app/components/PlayerBar.vue` / `app/components/MobileNowPlayingOverlay.vue`
- シャッフルボタンを `toggleShuffle()` から `handleShuffle()` に変更
  - `shuffleQueue()` 呼び出し後にトースト「キューをシャッフルしました」を表示
  - 曲が 1 曲以下のとき `disabled`
- トグル表示（`text-selected-text` のアクティブ色）を廃止（単発操作のため）

### `app/plugins/playback-persistence.client.ts`
- `PersistedQueue` 型から `shuffleMode` を削除
- 復元ロジック・watch 対象から `shuffleMode` を除去

### テスト
- `tests/unit/queueStore.test.ts`: `shuffleQueue()` テスト 5 件追加
- `tests/unit/playbackPersistence.test.ts`: 新仕様に更新、旧 `shuffleMode` データ耐性テストを追加

## 受け入れ条件 (チェックリスト)

- [x] シャッフル操作時に、現在再生中の曲がキュー先頭へ移動する
- [x] 現在曲以外の曲順だけがシャッフルされる
- [x] シャッフル後の `next` / `previous` が表示キュー順と一致する
- [x] `repeatMode` の既存挙動が維持される
- [x] シャッフルは単発のキュー並び替えとして扱われる
- [x] 再読込後も、シャッフル後のキュー順と現在位置が保持される
- [ ] 手動確認: デスクトップ `PlayerBar` とモバイル再生中詳細の両方からシャッフル操作できるか