### PR TITLE
fix: ピックアップの更新ボタンをリロードアイコン+更新テキストに変更 #79

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -13,10 +13,13 @@
             キューに追加
           </button>
           <button
-            class="text-sm text-gray-400 transition-colors hover:text-selected-text"
+            class="flex items-center gap-1.5 text-sm text-gray-400 transition-colors hover:text-selected-text"
+            title="ピックアップを更新"
+            aria-label="ピックアップを更新"
             @click="randomRefresh()"
           >
-            シャッフル
+            <FontAwesomeIcon :icon="['fas', 'arrow-rotate-right']" class="h-3.5 w-3.5" />
+            更新
           </button>
         </div>
       </div>


### PR DESCRIPTION
## 概要

トップページのピックアップ操作ボタンを「シャッフル」テキストから、リロード系アイコン + 「更新」テキストに変更しました。

## 変更内容

- `app/pages/index.vue`: ピックアップの操作ボタンを変更
  - `シャッフル`（テキストのみ）→ `arrow-rotate-right` アイコン + `更新` テキスト
  - `title` / `aria-label` に「ピックアップを更新」を付与
  - `randomRefresh()` の呼び出し経路は変更なし

## 受け入れ条件の確認

- [x] トップページのピックアップ操作が、キューシャッフルではなくピックアップ更新 / 再抽選と認識しやすい見た目になっている
- [x] クリック時の挙動は従来どおり `randomRefresh()` による候補更新のままである
- [x] コントロールバーのシャッフル操作（`fa-shuffle`）と見た目・意味が混同しにくい
- [x] `title` / `aria-label` などで操作意図が補われている
- [x] 既存 UI / 状態管理 / API 契約との整合が取れている

Closes #79