### PR TITLE
feat(home): トップに「最近よく聞く曲」セクションを追加する

### DIFF
--- a/app/composables/usePlayHistory.ts
+++ b/app/composables/usePlayHistory.ts
@@ -1,0 +1,105 @@
+import type { PlayEvent, Song } from '~/types'
+
+const EVENTS_KEY = 'play-history:events'
+const SONGS_KEY = 'play-history:songs'
+const MAX_EVENTS = 200
+const RETENTION_DAYS = 30
+const DECAY_HALF_LIFE_DAYS = 7
+/** Minimum qualified plays required for a song to appear in results. */
+const MIN_PLAY_COUNT = 2
+/** Number of top-scored candidates to pick from randomly. */
+const TOP_CANDIDATES = 15
+/** Number of songs to show in the section. */
+const DISPLAY_COUNT = 5
+
+function loadJson<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key)
+    return raw ? (JSON.parse(raw) as T) : fallback
+  } catch {
+    return fallback
+  }
+}
+
+function saveJson(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // Ignore quota / private mode errors
+  }
+}
+
+function pruneEvents(events: PlayEvent[]): PlayEvent[] {
+  const cutoff = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000
+  const recent = events.filter((e) => e.playedAt >= cutoff)
+  if (recent.length <= MAX_EVENTS) return recent
+  return recent.sort((a, b) => b.playedAt - a.playedAt).slice(0, MAX_EVENTS)
+}
+
+function shufflePick<T>(arr: T[], n: number): T[] {
+  const copy = [...arr]
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[copy[i], copy[j]] = [copy[j], copy[i]]
+  }
+  return copy.slice(0, n)
+}
+
+export function usePlayHistory() {
+  /**
+   * Record a qualified play for the given song.
+   * Also caches the Song object to avoid API fetches in getFrequentlyPlayed().
+   */
+  function recordPlay(song: Song): void {
+    const events = pruneEvents(loadJson<PlayEvent[]>(EVENTS_KEY, []))
+    events.push({ songId: song.id, playedAt: Date.now() })
+    saveJson(EVENTS_KEY, events)
+
+    const cache = loadJson<Record<number, Song>>(SONGS_KEY, {})
+    cache[song.id] = song
+    saveJson(SONGS_KEY, cache)
+  }
+
+  /**
+   * Returns up to DISPLAY_COUNT songs to show in the "最近よく聞く曲" section.
+   * Scores each song using exponential time-decay so recently played songs
+   * are weighted higher. Picks randomly from the top candidates so the
+   * section looks different on each visit.
+   */
+  function getFrequentlyPlayed(): Song[] {
+    const events = pruneEvents(loadJson<PlayEvent[]>(EVENTS_KEY, []))
+    if (events.length === 0) return []
+
+    const now = Date.now()
+
+    // Accumulate decay-weighted sum and raw count per song
+    const scoreMap = new Map<number, { weightSum: number; count: number }>()
+    for (const e of events) {
+      const daysAgo = (now - e.playedAt) / (1000 * 60 * 60 * 24)
+      const weight = Math.exp(-daysAgo / DECAY_HALF_LIFE_DAYS)
+      const entry = scoreMap.get(e.songId) ?? { weightSum: 0, count: 0 }
+      scoreMap.set(e.songId, { weightSum: entry.weightSum + weight, count: entry.count + 1 })
+    }
+
+    // score = log2(1 + count) × avgWeight
+    // This dampens the advantage of high repeat counts so that recently played
+    // songs outrank songs that were only played heavily in the distant past.
+    const calcScore = (v: { weightSum: number; count: number }) =>
+      Math.log2(1 + v.count) * (v.weightSum / v.count)
+
+    // Filter by minimum raw play count, then rank by score
+    const candidates = [...scoreMap.entries()]
+      .filter(([, v]) => v.count >= MIN_PLAY_COUNT)
+      .sort(([, a], [, b]) => calcScore(b) - calcScore(a))
+      .slice(0, TOP_CANDIDATES)
+      .map(([songId]) => songId)
+
+    if (candidates.length === 0) return []
+
+    const picked = shufflePick(candidates, DISPLAY_COUNT)
+    const cache = loadJson<Record<number, Song>>(SONGS_KEY, {})
+    return picked.map((id) => cache[id]).filter((s): s is Song => Boolean(s))
+  }
+
+  return { recordPlay, getFrequentlyPlayed }
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,5 +1,23 @@
 <template>
   <div class="space-y-10">
+    <!-- Frequently played (client-only: reads localStorage, hidden when history is empty) -->
+    <ClientOnly>
+      <section v-if="frequentSongs.length">
+        <div class="mb-4 flex items-center justify-between">
+          <h2 class="text-lg font-bold">最近よく聞く曲</h2>
+          <button
+            class="text-sm text-gray-400 transition-colors hover:text-selected-text"
+            @click="addAllToQueue(frequentSongs, '最近よく聞く曲')"
+          >
+            キューに追加
+          </button>
+        </div>
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+          <SongCard v-for="song in frequentSongs" :key="song.id" :song="song" />
+        </div>
+      </section>
+    </ClientOnly>
+
     <!-- Random picks -->
     <section>
       <div class="mb-4 flex items-center justify-between">
@@ -93,6 +111,12 @@ function addAllToQueue(songs: Song[], label: string) {
 }
 
 const { songs: randomSongs, status: randomStatus, refresh: randomRefresh } = useRandomSongs(10)
+
+const frequentSongs = ref<Song[]>([])
+onMounted(() => {
+  const { getFrequentlyPlayed } = usePlayHistory()
+  frequentSongs.value = getFrequentlyPlayed()
+})
 
 const { useApiFetch } = useApi()
 const { data: recentResponse, status: recentStatus } = await useApiFetch<SongsResponse>(

--- a/app/plugins/play-history.client.ts
+++ b/app/plugins/play-history.client.ts
@@ -1,0 +1,43 @@
+import type { Song } from '~/types'
+
+// Flat threshold seconds (used when song duration is unknown or very long)
+const FLAT_THRESHOLD_SEC = 20
+
+/**
+ * Returns the minimum seconds a song must be played for it to count as a
+ * qualified play. For short clips, 30% of the clip duration is used instead
+ * of the flat threshold to avoid inflating counts on short songs.
+ */
+function calcThreshold(song: Song): number {
+  if (song.end_at > 0) {
+    const duration = song.end_at - song.start_at
+    return Math.max(FLAT_THRESHOLD_SEC, duration * 0.3)
+  }
+  return FLAT_THRESHOLD_SEC
+}
+
+export default defineNuxtPlugin(() => {
+  const { loadedVideoId } = useYouTubePlayer()
+  const player = usePlayerStore()
+  const queue = useQueueStore()
+  const { recordPlay } = usePlayHistory()
+
+  let prevSong: Song | null = null
+  let accSeconds = 0
+
+  // Increment accumulated seconds every second while the player is active
+  setInterval(() => {
+    if (player.isPlaying) accSeconds++
+  }, 1000)
+
+  // When the video changes, flush the previous song's accumulated time and
+  // start tracking the new song. This fires for both manual plays and
+  // auto-advance to the next song.
+  watch(loadedVideoId, () => {
+    if (prevSong && accSeconds >= calcThreshold(prevSong)) {
+      recordPlay(prevSong)
+    }
+    prevSong = queue.currentSong ?? null
+    accSeconds = 0
+  })
+})

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -35,6 +35,13 @@ export interface Song extends SongBasic {
   video: VideoBasic
 }
 
+// --- Play History ---
+
+export interface PlayEvent {
+  songId: number
+  playedAt: number // Unix timestamp (ms)
+}
+
 // --- Playlist (API) ---
 
 export interface PlaylistItem {


### PR DESCRIPTION
Closes #102

## 概要

localStorage ベースの再生履歴を蓄積し、トップページに「最近よく聞く曲」セクションを追加する。

## 変更内容

### `app/types/index.ts`
- `PlayEvent` 型を追加（`songId: number`, `playedAt: number`）

### `app/composables/usePlayHistory.ts`（新規）
- `recordPlay(song)` — qualified play を `play-history:events` に記録。`Song` オブジェクトを `play-history:songs` にキャッシュ
- `getFrequentlyPlayed()` — 時間減衰スコアで上位候補を選出し、ランダム 5 件を返す

**スコアリング**
```
score = log2(1 + count) × avgWeight
avgWeight = Σ exp(-daysAgo / 7) / count
```
- 半減期 7 日の指数減衰で直近の再生を重視
- `log2(1 + count)` で回数の影響を対数で抑制 → 「2週間前20回 < 昨日2回」
- `playCount >= 2` を表示条件として誤タップ・即スキップを除外
- 上位 15 候補からランダム 5 件を抽出してリロードごとに変化

**Prune**
- 30 日より古いイベントを削除
- 200 件上限（超過時は新しい順に切り捨て）

### `app/plugins/play-history.client.ts`（新規）
- `analytics-tracker.client.ts` と同パターンで `loadedVideoId` を watch
- `player.isPlaying` 中に秒カウント
- 曲が変わった時点で前の曲の累積秒数を評価 → 閾値（20秒 or `duration × 30%` の大きい方）を超えていれば `recordPlay` を呼ぶ

### `app/pages/index.vue`
- ピックアップの上に `<ClientOnly>` で囲んだ「最近よく聞く曲」セクションを追加
- `onMounted` で `getFrequentlyPlayed()` を呼び表示（SSR では出力なし、hydration mismatch なし）
- `frequentSongs.length === 0` のときセクション丸ごと非表示

## スコープ外

- サーバー保存・ログイン連携
- 履歴クリア UI・履歴閲覧ページ
- 高度な推薦アルゴリズム