### PR TITLE
fix(play-history): 同一動画内の連続する曲クリップが記録されないバグを修正

### DIFF
--- a/app/plugins/play-history.client.ts
+++ b/app/plugins/play-history.client.ts
@@ -17,9 +17,7 @@ function calcThreshold(song: Song): number {
 }
 
 export default defineNuxtPlugin(() => {
-  const { loadedVideoId } = useYouTubePlayer()
   const player = usePlayerStore()
-  const queue = useQueueStore()
   const { recordPlay } = usePlayHistory()
 
   let prevSong: Song | null = null
@@ -30,14 +28,16 @@ export default defineNuxtPlugin(() => {
     if (player.isPlaying) accSeconds++
   }, 1000)
 
-  // When the video changes, flush the previous song's accumulated time and
-  // start tracking the new song. This fires for both manual plays and
-  // auto-advance to the next song.
-  watch(loadedVideoId, () => {
-    if (prevSong && accSeconds >= calcThreshold(prevSong)) {
-      recordPlay(prevSong)
-    }
-    prevSong = queue.currentSong ?? null
-    accSeconds = 0
-  })
+  // Watch currentSong ID instead of loadedVideoId so that consecutive songs
+  // from the same video (same videoId, different start_at) are each tracked.
+  watch(
+    () => player.currentSong?.id,
+    () => {
+      if (prevSong && accSeconds >= calcThreshold(prevSong)) {
+        recordPlay(prevSong)
+      }
+      prevSong = player.currentSong ?? null
+      accSeconds = 0
+    },
+  )
 })


### PR DESCRIPTION
## 問題

`play-history.client.ts` が `loadedVideoId`（YouTube 動画 ID）を watch していたため、同じ動画内に複数の曲クリップがある場合（`videoId` が同じで `start_at` が異なる曲が連続する場合）、曲が切り替わっても `loadedVideoId` が変化せず watch が発火しなかった。

→ 同一動画内の連続する曲が再生履歴に記録されないバグ。

## 修正

`loadedVideoId` の代わりに `player.currentSong?.id`（曲 ID）を watch するよう変更。

```ts
// 変更前
watch(loadedVideoId, () => { ... })

// 変更後
watch(() => player.currentSong?.id, () => { ... })
```

`player.currentSong` は `player.play(song)` の時点で更新されるため、同一動画内の曲切り替えでも確実に発火する。

## 影響範囲

- `app/plugins/play-history.client.ts` のみ
- 不要になった `useYouTubePlayer` と `useQueueStore` のインポートも削除
- ロジック・閾値・スコアリングに変更なし

## 関連

#102
