### PR TITLE
[player] iPhoneでYouTube PiP-friendlyなplayer構成にする

### DIFF
--- a/app/composables/useYouTubePlayer.ts
+++ b/app/composables/useYouTubePlayer.ts
@@ -53,13 +53,16 @@ export function useYouTubePlayer() {
     await loadApi()
     const origin = window.location.origin
     ytPlayer = new window.YT.Player(elementId, {
-      height: '1',
-      width: '1',
+      height: '360',
+      width: '640',
       playerVars: {
         autoplay: 0,
-        controls: 0,
-        disablekb: 1,
-        fs: 0,
+        // Enable native controls so that the YouTube UI is accessible when the
+        // player is visible (mobile overlay). playerVars cannot be changed after
+        // init, so we always set controls=1; the player is offscreen when the
+        // overlay is closed, making the controls functionally unavailable then.
+        controls: 1,
+        fs: 1,
         rel: 0,
         // Required for inline playback on iOS (prevents fullscreen takeover).
         playsinline: 1,


### PR DESCRIPTION
## 概要

iPhone で YouTube 公式 UI 経由の PiP を試せる構成へ寄せるため、YouTube IFrame Player の初期化オプションを見直した。

Closes #110

## 変更内容

### `app/composables/useYouTubePlayer.ts`

| 変数 | 変更前 | 変更後 |
|---|---|---|
| `height` | `'1'` | `'360'` |
| `width` | `'1'` | `'640'` |
| `controls` | `0` | `1` |
| `fs` | `0` | `1` |
| `disablekb` | `1` | 削除 |

## 設計の補足

- `playerVars` は初期化後に変更できないため `controls: 1` / `fs: 1` を常時設定している
- player は `MobileNowPlayingOverlay` が閉じている間は `position: fixed; top: -9999px; width: 1px; height: 1px` の offscreen 状態のため、controls は overlay 表示時のみユーザーに見える
- `playsinline: 1` は維持（iOS の全画面乗っ取り防止・user-gesture chain 保護のため必須）
- 将来デスクトップでも player を visible にする場合は、その時点で `controls` の条件付き管理を検討する

## PiP の仕様整理

PiP は YouTube / Safari / 端末側の条件依存であり、アプリから開始を保証しない。アプリは player host 条件を整えるにとどまる。

## テスト観点

- iPhone Safari 実機で MobileNowPlayingOverlay を開き、YouTube 公式 UI が表示されるか確認
- 再生中に PiP 導線が現れるか確認
- 再生 / 停止 / 次曲 / シークの回帰確認