### PR TITLE
[ui] モバイルで気づきやすい toast 配置に見直す

### DIFF
--- a/app/components/AppToastRegion.vue
+++ b/app/components/AppToastRegion.vue
@@ -1,10 +1,10 @@
 <template>
-  <!-- Toast container: fixed top-right, above all panels.
-       To swap the rendering to a library, replace this component only. -->
+  <!-- Toast container: bottom-center on mobile (above PlayerBar + MobileBottomNav),
+       top-right on desktop. To swap the rendering to a library, replace this component only. -->
   <Teleport to="body">
     <div
       v-if="store.items.length > 0"
-      class="fixed right-4 top-16 z-200 flex w-80 flex-col gap-2 lg:top-4"
+      class="fixed bottom-[calc(env(safe-area-inset-bottom)+8rem)] left-1/2 z-200 flex w-[calc(100vw-2rem)] max-w-xs -translate-x-1/2 flex-col gap-2 lg:bottom-auto lg:left-auto lg:right-4 lg:top-4 lg:w-80 lg:translate-x-0"
       role="status"
       aria-live="polite"
       aria-atomic="false"
@@ -47,7 +47,7 @@
 
           <!-- Dismiss -->
           <button
-            class="ml-auto shrink-0 p-1 text-gray-400 hover:text-white"
+            class="ml-auto shrink-0 p-2 text-gray-400 hover:text-white"
             aria-label="閉じる"
             @click="store.dismiss(item.id)"
           >
@@ -68,17 +68,23 @@ const store = useNotificationsStore()
 .toast-leave-active {
   transition:
     opacity 0.2s ease,
-    transform 0.2s ease;
+    translate 0.2s ease;
 }
 .toast-move {
   transition: transform 0.2s ease;
 }
-.toast-enter-from {
-  opacity: 0;
-  transform: translateX(1rem);
-}
+/* Mobile default: slide up from below */
+.toast-enter-from,
 .toast-leave-to {
   opacity: 0;
-  transform: translateX(1rem);
+  translate: 0 1rem;
+}
+/* Desktop: slide in from the right */
+@media (min-width: 1024px) {
+  .toast-enter-from,
+  .toast-leave-to {
+    opacity: 0;
+    translate: 1rem 0;
+  }
 }
 </style>


### PR DESCRIPTION
Closes #101

## 変更概要

`AppToastRegion.vue` のモバイル配置・アニメーション・タップターゲットを改善する。

## 変更内容

### 配置

| viewport | 変更前 | 変更後 |
|---|---|---|
| **Mobile** | 右上固定 `top-16 right-4` | 画面下部中央 `bottom-[calc(env(safe-area-inset-bottom)+8rem)] left-1/2 -translate-x-1/2` |
| **Desktop（lg+）** | `top-16 right-4` | `top-4 right-4`（微調整） |

`8rem`（128px）+ `safe-area-inset-bottom` により、PlayerBar（≈56px）+ MobileBottomNav（≈56px）の両方が表示されていても toast が隠れない。

### アニメーション

- CSS `translate` プロパティを使用することで Tailwind の `-translate-x-1/2` との干渉を回避
- Mobile: 下から上へスライドイン（`translate: 0 1rem`）
- Desktop（lg+）: 右からスライドイン（`translate: 1rem 0`）

### タップターゲット

- 閉じるボタン: `p-1` → `p-2`（タップしやすさ改善）

## スコープ外

- `useNotifications.ts` / `notifications.ts` の変更なし
- `default.vue` の構造変更なし
- 通知 duration・種別・メッセージ文言の変更なし

## 確認観点

- [ ] モバイル幅（390px）で通知を出したとき、PlayerBar + MobileBottomNav の上に toast が表示される
- [ ] PlayerBar 非表示時（楽曲未再生）でも MobileBottomNav に重ならない
- [ ] デスクトップ幅（1280px）で右上に表示・右スライドで入る（回帰）
- [ ] 閉じるボタンと「開く」リンクが押せる