### PR TITLE
feat: モバイルの楽曲行保存ボタンを bottom sheet に統一 (#114)

### DIFF
--- a/app/components/AddToPlaylistDropdown.vue
+++ b/app/components/AddToPlaylistDropdown.vue
@@ -8,9 +8,10 @@
       <FontAwesomeIcon :icon="['fas', 'bookmark']" class="h-4 w-4" />
     </button>
 
+    <!-- Desktop dropdown panel (hidden on mobile) -->
     <div
       v-if="open"
-      class="absolute top-full right-0 z-50 mt-1 w-52 border border-border-default bg-surface-raised shadow-lg"
+      class="absolute top-full right-0 z-50 mt-1 w-52 border border-border-default bg-surface-raised shadow-lg hidden lg:block"
       @click.stop
     >
       <!-- Create mode: inline name input -->
@@ -69,6 +70,14 @@
         </div>
       </template>
     </div>
+
+    <!-- Mobile bottom sheet (hidden on desktop via lg:hidden inside AddToPlaylistSheet) -->
+    <AddToPlaylistSheet
+      :open="open"
+      :song-id="songId"
+      :song-title="songTitle"
+      @close="open = false"
+    />
   </div>
 </template>
 

--- a/app/components/AddToPlaylistSheet.vue
+++ b/app/components/AddToPlaylistSheet.vue
@@ -12,6 +12,7 @@
       <div
         v-if="open"
         class="fixed inset-x-0 bottom-0 z-60 flex max-h-[60vh] flex-col border-t border-border-default bg-surface-raised lg:hidden"
+        @click.stop
       >
         <!-- Header -->
         <div class="flex items-center justify-between px-4 py-3">


### PR DESCRIPTION
## 概要

モバイル幅の楽曲行（`SongListItem` / `SongRowActions`）で保存ボタンを押したとき、再生オーバーレイと同じ bottom sheet UI でプレイリスト追加できるようにする。

closes #114

## 変更内容

### `app/components/AddToPlaylistDropdown.vue`
- dropdown パネル div に `hidden lg:block` を追加 → mobile では非表示
- テンプレート末尾に `<AddToPlaylistSheet>` を追加 → mobile で sheet が開く
  - `open` state を共有し、ボタン押下でどちらも制御

### `app/components/AddToPlaylistSheet.vue`
- sheet パネル div に `@click.stop` を追加
  - `Teleport to="body"` で body 直下に配置されるため、sheet 内クリックが document まで伝播して `AddToPlaylistDropdown` の outside-click handler に届き誤 close する問題を修正

## 変更しないもの
- `SongListItem.vue` / `SongRowActions.vue` / `app/pages/videos/[id].vue` は無変更
- プレイリスト操作ロジック（`usePlaylistActions` / store）は無変更
- desktop 幅の dropdown 体験は維持

## 動作まとめ

| viewport | ボタン押下 | 表示 |
|---|---|---|
| mobile (< lg) | `open = true` | sheet がスライドイン (`lg:hidden` が外れる) |
| desktop (>= lg) | `open = true` | dropdown パネルが表示 (`lg:block`) |

## 受け入れ条件の確認

- [x] モバイル幅で `/songs` の楽曲行から保存ボタンを押すと sheet が開く
- [x] モバイル幅で `/search` の楽曲行から保存ボタンを押すと sheet が開く
- [x] モバイル幅で `/videos/[id]` の収録楽曲行から保存ボタンを押すと sheet が開く
- [x] 既存プレイリスト追加・新規作成ともに sheet が閉じて success toast が出る
- [x] desktop 幅では dropdown が維持される
- [x] 保存ボタン押下で親行の再生が誤発火しない