### PR TITLE
[playlists] お気に入りプレイリストを追加する

### DIFF
--- a/app/components/FavoriteToggleButton.vue
+++ b/app/components/FavoriteToggleButton.vue
@@ -1,0 +1,34 @@
+<template>
+  <button
+    class="p-1 transition-colors"
+    :class="isFav ? 'text-selected-text' : 'text-gray-400 hover:text-white'"
+    :aria-pressed="isFav"
+    :title="isFav ? 'お気に入りから削除' : 'お気に入りに追加'"
+    @click.stop="handleToggle"
+  >
+    <FontAwesomeIcon
+      :icon="isFav ? ['fas', 'star'] : ['far', 'star']"
+      :class="size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4'"
+    />
+  </button>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    songId: number
+    songTitle: string
+    size?: 'sm' | 'md'
+  }>(),
+  { size: 'md' },
+)
+
+const playlistsStore = usePlaylistsStore()
+const { toggleFavoriteSong } = usePlaylistActions()
+
+const isFav = computed(() => playlistsStore.isFavorite(props.songId))
+
+function handleToggle() {
+  toggleFavoriteSong(props.songId, props.songTitle)
+}
+</script>

--- a/app/components/MobileNowPlayingOverlay.vue
+++ b/app/components/MobileNowPlayingOverlay.vue
@@ -130,6 +130,25 @@
 
         <!-- Sub-actions row -->
         <div class="flex items-center justify-around border-t border-border-default px-6 py-2">
+          <!-- Favorite toggle -->
+          <button
+            class="flex flex-col items-center gap-1 transition-colors"
+            :class="
+              playlistsStore.isFavorite(song.id)
+                ? 'text-selected-text'
+                : 'text-gray-400 hover:text-white'
+            "
+            :aria-pressed="playlistsStore.isFavorite(song.id)"
+            :title="playlistsStore.isFavorite(song.id) ? 'お気に入りから削除' : 'お気に入りに追加'"
+            @click="toggleFavoriteSong(song.id, song.title)"
+          >
+            <FontAwesomeIcon
+              :icon="playlistsStore.isFavorite(song.id) ? ['fas', 'star'] : ['far', 'star']"
+              class="h-5 w-5"
+            />
+            <span class="text-[10px]">お気に入り</span>
+          </button>
+
           <!-- Add to playlist -->
           <button
             class="flex flex-col items-center gap-1 text-gray-400 hover:text-white"
@@ -326,6 +345,8 @@ const player = usePlayerStore()
 const queue = useQueueStore()
 const overlay = useMobileNowPlayingOverlay()
 const { success } = useNotifications()
+const playlistsStore = usePlaylistsStore()
+const { toggleFavoriteSong } = usePlaylistActions()
 
 function handleShuffle() {
   queue.shuffleQueue()

--- a/app/components/PlayerBar.vue
+++ b/app/components/PlayerBar.vue
@@ -89,7 +89,7 @@
           class="h-12 w-12 shrink-0 object-cover transition-shadow duration-500 ease-out"
           :style="player.isPlaying ? 'box-shadow: 0 0 8px var(--color-playing-glow)' : ''"
         />
-        <div class="min-w-0">
+        <div class="min-w-0 flex-1">
           <NuxtLink
             :to="`/songs/${player.currentSong.id}`"
             class="block truncate text-sm font-medium hover:text-selected-text"
@@ -98,6 +98,12 @@
           </NuxtLink>
           <p class="truncate text-xs text-gray-400">{{ player.currentSong.artist }}</p>
         </div>
+        <FavoriteToggleButton
+          :song-id="player.currentSong.id"
+          :song-title="player.currentSong.title"
+          size="sm"
+          class="shrink-0"
+        />
       </div>
 
       <!-- Playback controls -->

--- a/app/components/SongCard.vue
+++ b/app/components/SongCard.vue
@@ -27,9 +27,18 @@
     </div>
 
     <!-- Info -->
-    <div class="p-3">
-      <p class="truncate text-sm font-medium" :title="song.title">{{ song.title }}</p>
-      <p class="mt-0.5 truncate text-xs text-gray-400">{{ song.artist ?? '不明' }}</p>
+    <div class="flex items-start gap-1 p-3">
+      <div class="min-w-0 flex-1">
+        <p class="truncate text-sm font-medium" :title="song.title">{{ song.title }}</p>
+        <p class="mt-0.5 truncate text-xs text-gray-400">{{ song.artist ?? '不明' }}</p>
+      </div>
+      <FavoriteToggleButton
+        :song-id="song.id"
+        :song-title="song.title"
+        size="sm"
+        class="shrink-0 transition-opacity"
+        :class="isFavoriteSong ? '' : 'sm:opacity-0 sm:group-hover:opacity-100'"
+      />
     </div>
   </div>
 </template>
@@ -42,7 +51,10 @@ const queueActions = useQueueActions()
 const { songDuration } = useFormatTime()
 const player = usePlayerStore()
 
+const playlistsStore = usePlaylistsStore()
+
 const isCurrentlyPlaying = computed(
   () => player.currentSong?.id === props.song.id && player.isPlaying,
 )
+const isFavoriteSong = computed(() => playlistsStore.isFavorite(props.song.id))
 </script>

--- a/app/components/SongListItem.vue
+++ b/app/components/SongListItem.vue
@@ -51,6 +51,15 @@
     </span>
 
     <!-- Actions -->
+    <!-- Favorite button: always visible for favorites, hover-only for non-favorites -->
+    <FavoriteToggleButton
+      v-if="showFavorite"
+      :song-id="song.id"
+      :song-title="song.title"
+      size="sm"
+      class="shrink-0 transition-opacity"
+      :class="isFavoriteSong ? '' : 'sm:opacity-0 sm:group-hover:opacity-100'"
+    />
     <div
       class="flex shrink-0 gap-2 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:[&:has(.dropdown-open)]:opacity-100"
     >
@@ -83,13 +92,16 @@ const props = withDefaults(
     index: number
     showIndex?: boolean
     showAddToPlaylist?: boolean
+    showFavorite?: boolean
   }>(),
-  { showIndex: true, showAddToPlaylist: true },
+  { showIndex: true, showAddToPlaylist: true, showFavorite: true },
 )
 
 const player = usePlayerStore()
+const playlistsStore = usePlaylistsStore()
 const queueActions = useQueueActions()
 const { songDuration } = useFormatTime()
 
 const isActive = computed(() => player.currentSong?.id === props.song.id)
+const isFavoriteSong = computed(() => playlistsStore.isFavorite(props.song.id))
 </script>

--- a/app/components/SongListItem.vue
+++ b/app/components/SongListItem.vue
@@ -66,7 +66,7 @@
       <slot name="extra-actions" />
       <AddToPlaylistDropdown v-if="showAddToPlaylist" :song-id="song.id" :song-title="song.title" />
       <button
-        class="p-1 text-gray-400 hover:text-white"
+        class="hidden p-1 text-gray-400 hover:text-white sm:block"
         title="次に再生"
         @click.stop="queueActions.playNext(song)"
       >

--- a/app/components/SongRowActions.vue
+++ b/app/components/SongRowActions.vue
@@ -1,31 +1,44 @@
 <template>
-  <div
-    class="flex shrink-0 gap-2 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:[&:has(.dropdown-open)]:opacity-100"
-  >
-    <AddToPlaylistDropdown :song-id="song.id" :song-title="song.title" />
-    <button
-      class="p-1 text-gray-400 hover:text-white"
-      title="次に再生"
-      @click.stop="queueActions.playNext(song)"
+  <div class="flex shrink-0 items-center gap-2">
+    <!-- Favorite button: always visible for favorites, hover-only for non-favorites -->
+    <FavoriteToggleButton
+      :song-id="song.id"
+      :song-title="song.title"
+      size="sm"
+      class="transition-opacity"
+      :class="isFavoriteSong ? '' : 'sm:opacity-0 sm:group-hover:opacity-100'"
+    />
+    <div
+      class="flex shrink-0 gap-2 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:[&:has(.dropdown-open)]:opacity-100"
     >
-      <FontAwesomeIcon :icon="['fas', 'angles-right']" class="h-4 w-4" />
-    </button>
-    <button
-      class="p-1 text-gray-400 hover:text-white"
-      title="キューに追加"
-      @click.stop="queueActions.addToQueue(song)"
-    >
-      <FontAwesomeIcon :icon="['fas', 'plus']" class="h-4 w-4" />
-    </button>
+      <AddToPlaylistDropdown :song-id="song.id" :song-title="song.title" />
+      <button
+        class="p-1 text-gray-400 hover:text-white"
+        title="次に再生"
+        @click.stop="queueActions.playNext(song)"
+      >
+        <FontAwesomeIcon :icon="['fas', 'angles-right']" class="h-4 w-4" />
+      </button>
+      <button
+        class="p-1 text-gray-400 hover:text-white"
+        title="キューに追加"
+        @click.stop="queueActions.addToQueue(song)"
+      >
+        <FontAwesomeIcon :icon="['fas', 'plus']" class="h-4 w-4" />
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { Song } from '~/types'
 
-defineProps<{
+const props = defineProps<{
   song: Song
 }>()
 
+const playlistsStore = usePlaylistsStore()
 const queueActions = useQueueActions()
+
+const isFavoriteSong = computed(() => playlistsStore.isFavorite(props.song.id))
 </script>

--- a/app/components/SongRowActions.vue
+++ b/app/components/SongRowActions.vue
@@ -13,7 +13,7 @@
     >
       <AddToPlaylistDropdown :song-id="song.id" :song-title="song.title" />
       <button
-        class="p-1 text-gray-400 hover:text-white"
+        class="hidden p-1 text-gray-400 hover:text-white sm:block"
         title="次に再生"
         @click.stop="queueActions.playNext(song)"
       >

--- a/app/composables/useAnalytics.ts
+++ b/app/composables/useAnalytics.ts
@@ -8,6 +8,8 @@ export type PlaylistAction =
   | 'rename'
   | 'remove_song'
   | 'delete'
+  | 'add_favorite'
+  | 'remove_favorite'
 export type YouTubeClickSource = 'video_detail' | 'mobile_overlay'
 
 export function useAnalytics() {

--- a/app/composables/usePlaylistActions.ts
+++ b/app/composables/usePlaylistActions.ts
@@ -1,4 +1,5 @@
 import type { LocalPlaylist } from '~/types'
+import { FAVORITES_PLAYLIST_ID } from '~/stores/playlists'
 
 export function usePlaylistActions() {
   const playlistsStore = usePlaylistsStore()
@@ -72,6 +73,20 @@ export function usePlaylistActions() {
     trackPlaylistAction('delete', { id: playlistId, name: playlistName })
   }
 
+  /** Toggle favorite status for a song */
+  function toggleFavoriteSong(songId: number, songTitle: string) {
+    const wasFavorite = playlistsStore.isFavorite(songId)
+    playlistsStore.toggleFavorite(songId)
+    const fav = playlistsStore.getById(FAVORITES_PLAYLIST_ID)
+    if (wasFavorite) {
+      success(`「${songTitle}」をお気に入りから削除しました`)
+      if (fav) trackPlaylistAction('remove_favorite', fav, { song_id: songId })
+    } else {
+      success(`「${songTitle}」をお気に入りに追加しました`, `/playlists/${FAVORITES_PLAYLIST_ID}`)
+      if (fav) trackPlaylistAction('add_favorite', fav, { song_id: songId })
+    }
+  }
+
   return {
     addSongToPlaylist,
     createPlaylistWithSong,
@@ -81,5 +96,6 @@ export function usePlaylistActions() {
     renamePlaylist,
     removeSongFromPlaylist,
     deletePlaylist,
+    toggleFavoriteSong,
   }
 }

--- a/app/pages/playlists/[id].vue
+++ b/app/pages/playlists/[id].vue
@@ -55,7 +55,7 @@
               {{ playlist.description }}
             </p>
           </div>
-          <div class="flex shrink-0 gap-2">
+          <div v-if="playlist.kind !== 'favorites'" class="flex shrink-0 gap-2">
             <button class="px-2 py-1 text-xs text-gray-400 hover:text-white" @click="startEdit">
               編集
             </button>
@@ -128,11 +128,14 @@
                 :index="index"
                 :show-index="false"
                 :show-add-to-playlist="false"
+                :show-favorite="false"
               >
                 <template #extra-actions>
                   <button
                     class="p-1 text-red-400/60 hover:text-red-400"
-                    title="プレイリストから削除"
+                    :title="
+                      playlist.kind === 'favorites' ? 'お気に入りから削除' : 'プレイリストから削除'
+                    "
                     @click.stop="handleRemoveSong(index)"
                   >
                     <FontAwesomeIcon :icon="['fas', 'trash']" class="h-4 w-4" />

--- a/app/pages/playlists/index.vue
+++ b/app/pages/playlists/index.vue
@@ -48,8 +48,12 @@
         :to="`/playlists/${pl.id}`"
         class="group flex items-center gap-4 border-b border-border-default px-3 py-3 transition-colors hover:bg-surface-overlay"
       >
-        <!-- List icon -->
-        <FontAwesomeIcon :icon="['fas', 'list']" class="h-5 w-5 shrink-0 text-gray-500" />
+        <!-- Icon: favorites uses star, others use list -->
+        <FontAwesomeIcon
+          :icon="pl.kind === 'favorites' ? ['fas', 'star'] : ['fas', 'list']"
+          class="h-5 w-5 shrink-0"
+          :class="pl.kind === 'favorites' ? 'text-selected-text' : 'text-gray-500'"
+        />
 
         <!-- Info -->
         <div class="min-w-0 flex-1">

--- a/app/pages/songs/[id].vue
+++ b/app/pages/songs/[id].vue
@@ -37,6 +37,7 @@
           >
             キューに追加
           </button>
+          <FavoriteToggleButton :song-id="song.id" :song-title="song.title" size="md" />
         </div>
       </div>
     </div>

--- a/app/plugins/fontawesome.ts
+++ b/app/plugins/fontawesome.ts
@@ -37,6 +37,7 @@ import {
   faArrowLeft,
 } from '@fortawesome/free-solid-svg-icons'
 import { faYoutube, faXTwitter } from '@fortawesome/free-brands-svg-icons'
+import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons'
 
 // Prevent double CSS loading — managed via nuxt.config.ts css[]
 config.autoAddCss = false
@@ -76,6 +77,8 @@ library.add(
   faArrowUpRightFromSquare,
   faGear,
   faArrowLeft,
+  // Regular
+  faStarRegular,
   // Brands
   faYoutube,
   faXTwitter,

--- a/app/stores/playlists.ts
+++ b/app/stores/playlists.ts
@@ -1,10 +1,39 @@
 import type { LocalPlaylist, LocalPlaylistItem } from '~/types'
 
 const STORAGE_KEY = 'local_playlists'
+export const FAVORITES_PLAYLIST_ID = 'favorites'
+
+function buildFavoritesPlaylist(): LocalPlaylist {
+  const now = new Date().toISOString()
+  return {
+    id: FAVORITES_PLAYLIST_ID,
+    name: 'お気に入り',
+    description: '',
+    items: [],
+    created_at: now,
+    updated_at: now,
+    kind: 'favorites',
+  }
+}
 
 export const usePlaylistsStore = defineStore('playlists', () => {
   const playlists = ref<LocalPlaylist[]>([])
   const loaded = ref(false)
+
+  /** Ensure the favorites playlist always exists at the front */
+  function ensureFavoritesPlaylist() {
+    const exists = playlists.value.some((p) => p.id === FAVORITES_PLAYLIST_ID)
+    if (!exists) {
+      playlists.value.unshift(buildFavoritesPlaylist())
+    } else {
+      // Move favorites to front if it isn't already
+      const idx = playlists.value.findIndex((p) => p.id === FAVORITES_PLAYLIST_ID)
+      if (idx > 0) {
+        const [fav] = playlists.value.splice(idx, 1)
+        playlists.value.unshift(fav!)
+      }
+    }
+  }
 
   function loadFromStorage() {
     if (loaded.value) return
@@ -16,6 +45,7 @@ export const usePlaylistsStore = defineStore('playlists', () => {
     } catch {
       playlists.value = []
     }
+    ensureFavoritesPlaylist()
     loaded.value = true
   }
 
@@ -54,6 +84,7 @@ export const usePlaylistsStore = defineStore('playlists', () => {
   function updatePlaylist(id: string, data: { name?: string; description?: string }) {
     const playlist = getById(id)
     if (!playlist) return
+    if (playlist.kind === 'favorites') return // system playlist: no-op
     if (data.name !== undefined) playlist.name = data.name
     if (data.description !== undefined) playlist.description = data.description
     playlist.updated_at = new Date().toISOString()
@@ -63,6 +94,7 @@ export const usePlaylistsStore = defineStore('playlists', () => {
   function deletePlaylist(id: string) {
     const index = playlists.value.findIndex((p) => p.id === id)
     if (index === -1) return
+    if (playlists.value[index]?.kind === 'favorites') return // system playlist: no-op
     playlists.value.splice(index, 1)
     saveToStorage()
   }
@@ -119,6 +151,48 @@ export const usePlaylistsStore = defineStore('playlists', () => {
     saveToStorage()
   }
 
+  // --- Favorites helpers ---
+
+  function isFavorite(songId: number): boolean {
+    const fav = getById(FAVORITES_PLAYLIST_ID)
+    return fav?.items.some((item) => item.song_id === songId) ?? false
+  }
+
+  function addFavorite(songId: number) {
+    ensureFavoritesPlaylist()
+    const fav = getById(FAVORITES_PLAYLIST_ID)
+    if (!fav) return
+    if (fav.items.some((item) => item.song_id === songId)) return // no duplicates
+    fav.items.push({
+      id: crypto.randomUUID(),
+      song_id: songId,
+      order: fav.items.length,
+    })
+    fav.updated_at = new Date().toISOString()
+    saveToStorage()
+  }
+
+  function removeFavorite(songId: number) {
+    const fav = getById(FAVORITES_PLAYLIST_ID)
+    if (!fav) return
+    const idx = fav.items.findIndex((item) => item.song_id === songId)
+    if (idx === -1) return
+    fav.items.splice(idx, 1)
+    fav.items.forEach((item, i) => {
+      item.order = i
+    })
+    fav.updated_at = new Date().toISOString()
+    saveToStorage()
+  }
+
+  function toggleFavorite(songId: number) {
+    if (isFavorite(songId)) {
+      removeFavorite(songId)
+    } else {
+      addFavorite(songId)
+    }
+  }
+
   return {
     playlists: readonly(playlists),
     loaded: readonly(loaded),
@@ -131,5 +205,9 @@ export const usePlaylistsStore = defineStore('playlists', () => {
     addSongs,
     removeSong,
     reorderItems,
+    isFavorite,
+    addFavorite,
+    removeFavorite,
+    toggleFavorite,
   }
 })

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -67,12 +67,13 @@ export interface LocalPlaylistItem {
 }
 
 export interface LocalPlaylist {
-  id: string // UUID
+  id: string // UUID or 'favorites'
   name: string
   description: string
   items: LocalPlaylistItem[]
   created_at: string // ISO 8601
   updated_at: string // ISO 8601
+  kind?: 'user' | 'favorites' // undefined means 'user' for backward compat
 }
 
 // --- API Response Wrappers (dynamic-rest format) ---

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-brands-svg-icons": "^7.2.0",
+    "@fortawesome/free-regular-svg-icons": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@fortawesome/vue-fontawesome": "^3.1.3",
     "@pinia/nuxt": "^0.11.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@fortawesome/free-brands-svg-icons':
         specifier: ^7.2.0
         version: 7.2.0
+      '@fortawesome/free-regular-svg-icons':
+        specifier: ^7.2.0
+        version: 7.2.0
       '@fortawesome/free-solid-svg-icons':
         specifier: ^7.2.0
         version: 7.2.0
@@ -490,6 +493,10 @@ packages:
 
   '@fortawesome/free-brands-svg-icons@7.2.0':
     resolution: {integrity: sha512-VNG8xqOip1JuJcC3zsVsKRQ60oXG9+oYNDCosjoU/H9pgYmLTEwWw8pE0jhPz/JWdHeUuK6+NQ3qsM4gIbdbYQ==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/free-regular-svg-icons@7.2.0':
+    resolution: {integrity: sha512-iycmlN51EULlQ4D/UU9WZnHiN0CvjJ2TuuCrAh+1MVdzD+4ViKYH2deNAll4XAAYlZa8WAefHR5taSK8hYmSMw==}
     engines: {node: '>=6'}
 
   '@fortawesome/free-solid-svg-icons@7.2.0':
@@ -5092,6 +5099,10 @@ snapshots:
       '@fortawesome/fontawesome-common-types': 7.2.0
 
   '@fortawesome/free-brands-svg-icons@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/free-regular-svg-icons@7.2.0':
     dependencies:
       '@fortawesome/fontawesome-common-types': 7.2.0
 

--- a/tests/unit/playlistsStore.test.ts
+++ b/tests/unit/playlistsStore.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePlaylistsStore, FAVORITES_PLAYLIST_ID } from '../../app/stores/playlists'
+
+// localStorage mock
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      store[key] = undefined as unknown as string
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+describe('usePlaylistsStore - favorites', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('loadFromStorage 後に favorites プレイリストが先頭に存在する', () => {
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    expect(store.playlists.length).toBeGreaterThanOrEqual(1)
+    expect(store.playlists[0]?.id).toBe(FAVORITES_PLAYLIST_ID)
+    expect(store.playlists[0]?.kind).toBe('favorites')
+  })
+
+  it('localStorage にデータがある場合も favorites が先頭に挿入される', () => {
+    const existing = [
+      {
+        id: 'abc',
+        name: 'My list',
+        description: '',
+        items: [],
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ]
+    localStorageMock.setItem('local_playlists', JSON.stringify(existing))
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    expect(store.playlists[0]?.id).toBe(FAVORITES_PLAYLIST_ID)
+    expect(store.playlists.length).toBe(2)
+  })
+
+  it('isFavorite は未追加の楽曲で false を返す', () => {
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    expect(store.isFavorite(1)).toBe(false)
+  })
+
+  it('addFavorite で楽曲が追加され isFavorite が true になる', () => {
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    store.addFavorite(42)
+    expect(store.isFavorite(42)).toBe(true)
+    const fav = store.getById(FAVORITES_PLAYLIST_ID)
+    expect(fav?.items.length).toBe(1)
+    expect(fav?.items[0]?.song_id).toBe(42)
+  })
+
+  it('addFavorite は同じ song_id を重複登録しない', () => {
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    store.addFavorite(42)
+    store.addFavorite(42)
+    const fav = store.getById(FAVORITES_PLAYLIST_ID)
+    expect(fav?.items.length).toBe(1)
+  })
+
+  it('removeFavorite で楽曲が削除され isFavorite が false になる', () => {
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    store.addFavorite(42)
+    store.removeFavorite(42)
+    expect(store.isFavorite(42)).toBe(false)
+  })
+
+  it('toggleFavorite は追加と削除を交互に行う', () => {
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    store.toggleFavorite(99)
+    expect(store.isFavorite(99)).toBe(true)
+    store.toggleFavorite(99)
+    expect(store.isFavorite(99)).toBe(false)
+  })
+
+  it('updatePlaylist は favorites に対して no-op', () => {
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    store.updatePlaylist(FAVORITES_PLAYLIST_ID, { name: 'Hacked' })
+    expect(store.getById(FAVORITES_PLAYLIST_ID)?.name).toBe('お気に入り')
+  })
+
+  it('deletePlaylist は favorites に対して no-op', () => {
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    store.deletePlaylist(FAVORITES_PLAYLIST_ID)
+    expect(store.getById(FAVORITES_PLAYLIST_ID)).toBeDefined()
+  })
+
+  it('loadFromStorage を 2 回呼んでも favorites が 1 つだけ存在する', () => {
+    const store = usePlaylistsStore()
+    store.loadFromStorage()
+    // loaded フラグにより 2 回目はスキップされるが、favorites は維持される
+    store.loadFromStorage()
+    const favCount = store.playlists.filter((p) => p.id === FAVORITES_PLAYLIST_ID).length
+    expect(favCount).toBe(1)
+  })
+})


### PR DESCRIPTION
## 概要

Issue #117 の実装。システムプレイリスト「お気に入り」を追加し、楽曲UIの各所にスター切り替えボタンを配置する。

## 変更内容

### 型・ストア
- `LocalPlaylist` に `kind?: 'user' | 'favorites'` フィールドを追加（後方互換あり）
- `usePlaylistsStore` に favorites 専用メソッドを追加
  - `isFavorite(songId)`, `addFavorite`, `removeFavorite`, `toggleFavorite`
  - `FAVORITES_PLAYLIST_ID = 'favorites'`（エクスポート定数）
  - `ensureFavoritesPlaylist()` — `loadFromStorage()` 時に自動生成、常にリスト先頭
  - `updatePlaylist` / `deletePlaylist` にシステムプレイリスト保護ガードを追加
- `usePlaylistActions` に `toggleFavoriteSong(songId, songTitle)` を追加（トースト・アナリティクス付き）
- `PlaylistAction` 型に `'add_favorite' | 'remove_favorite'` を追加

### コンポーネント
- `FavoriteToggleButton.vue` を新規作成
  - props: `songId`, `songTitle`, `size?: 'sm' | 'md'`
  - お気に入り済み: 塗りつぶし星（`['fas', 'star']`）、`text-selected-text`、常時表示
  - 未お気に入り: アウトライン星（`['far', 'star']`）、`text-gray-400`、ホバー時のみ表示（SM以上）
  - `aria-pressed` 対応
- `@fortawesome/free-regular-svg-icons` を追加インストール（アウトライン星アイコン用）

### 配置箇所
| コンポーネント | 配置場所 |
|---|---|
| `SongListItem.vue` | アクション列（`showFavorite` prop で非表示可） |
| `SongRowActions.vue` | ホバーアクション群の外（常時/ホバー判定） |
| `SongCard.vue` | 情報エリア右端 |
| `PlayerBar.vue` | デスクトップ曲情報エリア右端 |
| `MobileNowPlayingOverlay.vue` | サブアクション行の先頭 |
| `songs/[id].vue` | アクションボタン群 |

### プレイリスト画面
- `playlists/index.vue`: お気に入りプレイリストにスターアイコン + `text-selected-text` 表示
- `playlists/[id].vue`:
  - お気に入りプレイリストで編集・削除ボタンを非表示
  - 曲行のスターボタンを非表示（`:show-favorite="false"`）

### テスト
- `tests/unit/playlistsStore.test.ts` を新規作成（10ケース）
  - favorites プレイリスト自動生成、先頭挿入、`isFavorite`、重複防止、`toggleFavorite`、システムプレイリスト保護、二重ロード冪等性

Closes #117